### PR TITLE
Simplify tag generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,24 @@ Works with PostgreSQL and TypeScript.
 
 ### Example:
 
-Query code:
-```js
+Query code in `users/queries.ts`:
+```ts
 import { sql } from "@pgtyped/query";
+import { ISelectUserIdsQuery } from "./queries.types.ts";
 
-export const selectUserIds = sql<
-  ISelectUserIdsResult, ISelectUserIdsParams
-  >`select id from users where id = $id and age = $age`;
-`;
+export const selectUserIds = sql<ISelectUserIdsQuery>`select id from users where id = $id and age = $age`;
 ```
 
-Generated TypeScript interfaces:
+PgTyped parses `sql` queries and generates corresponding TS interfaces in `users/queries.types.ts`:
 ```ts
+/** Types generated for queries found in "users/queries.ts" */
+
+/** 'selectUserIds' query type */
+export interface ISelectUserIdsQuery {
+  params: ISelectUserIdsParams;
+  result: ISelectUserIdsResult;
+}
+
 /** 'selectUserIds' parameters type */
 export interface ISelectUserIdsParams {
   id: string | null;

--- a/packages/cli/src/generator.test.ts
+++ b/packages/cli/src/generator.test.ts
@@ -59,6 +59,12 @@ export interface IDeleteUsersResult {
   bote: string | null;
 }
 
+/** 'DeleteUsers' query type */
+export interface IDeleteUsersQuery {
+  params: IDeleteUsersParams;
+  result: IDeleteUsersResult;
+}
+
 `;
   expect(result).toEqual(expected);
 });

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -88,7 +88,8 @@ export async function queryToTypeDeclarations(
   const interfaceName = pascalCase(query.name);
 
   if ("errorCode" in typeData) {
-    debug("Error in query. Details: %o", typeData);
+    // tslint:disable-next-line:no-console
+    console.error("Error in query. Details: %o", typeData);
     const returnInterface = generateTypeAlias(`I${interfaceName}Result`, "never");
     const paramInterface = generateTypeAlias(`I${interfaceName}Params`, "never");
     const resultErrorComment = `/** Query '${query.name}' is invalid, so its result is assigned type 'never' */\n`;
@@ -153,6 +154,7 @@ export async function queryToTypeDeclarations(
     }
   }
 
+  const resultInterfaceName = `I${interfaceName}Result`;
   const returnTypesInterface =
     `/** '${query.name}' return type */\n` + (
       returnFieldTypes.length > 0
@@ -160,9 +162,10 @@ export async function queryToTypeDeclarations(
           `I${interfaceName}Result`,
           returnFieldTypes,
         )
-        : generateTypeAlias(`I${interfaceName}Result`, "void")
+        : generateTypeAlias(resultInterfaceName, "void")
     );
 
+  const paramInterfaceName = `I${interfaceName}Params`;
   const paramTypesInterface =
     `/** '${query.name}' parameters type */\n` + (
       paramFieldTypes.length > 0
@@ -170,10 +173,18 @@ export async function queryToTypeDeclarations(
           `I${interfaceName}Params`,
           paramFieldTypes,
         )
-        : generateTypeAlias(`I${interfaceName}Params`, "void")
+        : generateTypeAlias(paramInterfaceName, "void")
     );
 
-  const interfaces = `${paramTypesInterface}${returnTypesInterface}`;
+  const typePairInterface =
+    `/** '${query.name}' query type */\n` + generateInterface(
+    `I${interfaceName}Query`,
+    [
+      {fieldName: "params", fieldType: paramInterfaceName},
+      {fieldName: "result", fieldType: resultInterfaceName},
+    ]);
+
+  const interfaces = `${paramTypesInterface}${returnTypesInterface}${typePairInterface}`;
 
   return interfaces;
 }

--- a/packages/example/src/books/queries.ts
+++ b/packages/example/src/books/queries.ts
@@ -2,14 +2,10 @@ import query from "@pgtyped/query";
 const { sql } = query;
 
 import {
-  ISelectAllBooksParams, ISelectAllBooksResult,
-  IDeleteBooksResult, IDeleteBooksParams,
+  ISelectAllBooksQuery,
+  IDeleteBooksQuery,
 } from "./queries.types";
 
-export const selectAllBooks = sql<
-  ISelectAllBooksResult, ISelectAllBooksParams
-  >`select * from books`;
+export const selectAllBooks = sql<ISelectAllBooksQuery>`select * from books`;
 
-export const deleteBooks = sql<
-  IDeleteBooksResult, IDeleteBooksParams
-  >`delete from books * where id = $id`;
+export const deleteBooks = sql<IDeleteBooksQuery>`delete from books * where id = $id`;

--- a/packages/example/src/books/queries.types.ts
+++ b/packages/example/src/books/queries.types.ts
@@ -10,6 +10,12 @@ export interface ISelectAllBooksResult {
   author_name: string | null;
 }
 
+/** 'selectAllBooks' query type */
+export interface ISelectAllBooksQuery {
+  params: ISelectAllBooksParams;
+  result: ISelectAllBooksResult;
+}
+
 /** 'deleteBooks' parameters type */
 export interface IDeleteBooksParams {
   id: number | null;
@@ -17,3 +23,9 @@ export interface IDeleteBooksParams {
 
 /** 'deleteBooks' return type */
 export type IDeleteBooksResult = void;
+
+/** 'deleteBooks' query type */
+export interface IDeleteBooksQuery {
+  params: IDeleteBooksParams;
+  result: IDeleteBooksResult;
+}

--- a/packages/example/src/books/queries.types.ts
+++ b/packages/example/src/books/queries.types.ts
@@ -16,6 +16,7 @@ export interface ISelectAllBooksQuery {
   result: ISelectAllBooksResult;
 }
 
+
 /** 'deleteBooks' parameters type */
 export interface IDeleteBooksParams {
   id: number | null;
@@ -29,3 +30,5 @@ export interface IDeleteBooksQuery {
   params: IDeleteBooksParams;
   result: IDeleteBooksResult;
 }
+
+

--- a/packages/example/src/users/queries.ts
+++ b/packages/example/src/users/queries.ts
@@ -1,19 +1,12 @@
 import { sql } from "@pgtyped/query";
 
 import {
-  ISelectAllUsersParams, ISelectAllUsersResult,
-  IInsertUsersParams, IInsertUsersResult,
-  ISelectUserIdsParams, ISelectUserIdsResult,
+  IInsertUsersQuery,
+  ISelectAllUsersQuery, ISelectUserIdsQuery,
 } from "./queries.types";
 
-export const selectAllUsers = sql<
-  ISelectAllUsersResult, ISelectAllUsersParams
-  >`select id, name from users where age in $$ages`;
+export const selectAllUsers = sql<ISelectAllUsersQuery>`select id, name from users where age in $$ages`;
 
-export const insertUsers = sql<
-  IInsertUsersResult, IInsertUsersParams
-  >`insert into users (name, age) values $users(name, age) returning id, name`;
+export const insertUsers = sql<IInsertUsersQuery>`insert into users (name, age) values $users(name, age) returning id, name`;
 
-export const selectUserIds = sql<
-  ISelectUserIdsResult, ISelectUserIdsParams
-  >`select id from users where id = $id and age = $age`;
+export const selectUserIds = sql<ISelectUserIdsQuery>`select id from users where id = $id and age = $age`;

--- a/packages/example/src/users/queries.types.ts
+++ b/packages/example/src/users/queries.types.ts
@@ -11,6 +11,12 @@ export interface ISelectAllUsersResult {
   name: string | null;
 }
 
+/** 'selectAllUsers' query type */
+export interface ISelectAllUsersQuery {
+  params: ISelectAllUsersParams;
+  result: ISelectAllUsersResult;
+}
+
 /** 'insertUsers' parameters type */
 export interface IInsertUsersParams {
   users: {
@@ -25,6 +31,12 @@ export interface IInsertUsersResult {
   name: string | null;
 }
 
+/** 'insertUsers' query type */
+export interface IInsertUsersQuery {
+  params: IInsertUsersParams;
+  result: IInsertUsersResult;
+}
+
 /** 'selectUserIds' parameters type */
 export interface ISelectUserIdsParams {
   id: number | null;
@@ -34,4 +46,10 @@ export interface ISelectUserIdsParams {
 /** 'selectUserIds' return type */
 export interface ISelectUserIdsResult {
   id: number;
+}
+
+/** 'selectUserIds' query type */
+export interface ISelectUserIdsQuery {
+  params: ISelectUserIdsParams;
+  result: ISelectUserIdsResult;
 }

--- a/packages/example/src/users/queries.types.ts
+++ b/packages/example/src/users/queries.types.ts
@@ -17,11 +17,12 @@ export interface ISelectAllUsersQuery {
   result: ISelectAllUsersResult;
 }
 
+
 /** 'insertUsers' parameters type */
 export interface IInsertUsersParams {
   users: {
     name: string,
-    age: number,
+    age: number
   };
 }
 
@@ -36,6 +37,7 @@ export interface IInsertUsersQuery {
   params: IInsertUsersParams;
   result: IInsertUsersResult;
 }
+
 
 /** 'selectUserIds' parameters type */
 export interface ISelectUserIdsParams {
@@ -53,3 +55,5 @@ export interface ISelectUserIdsQuery {
   params: ISelectUserIdsParams;
   result: ISelectUserIdsResult;
 }
+
+

--- a/packages/query/src/tag.ts
+++ b/packages/query/src/tag.ts
@@ -7,11 +7,11 @@ interface IDatabaseConnection {
   query: (query: string, bindings: any[]) => Promise<{ rows: any[] }>;
 }
 
-export class TaggedQuery<TResult, TParams> {
+export class TaggedQuery<TTypePair extends {params: any, result: any}> {
   public run: (
-    params: TParams,
+    params: TTypePair["params"],
     dbConnection: IDatabaseConnection,
-  ) => Promise<TResult[]>;
+  ) => Promise<TTypePair["result"]>;
 
   private query: string;
 
@@ -28,8 +28,13 @@ export class TaggedQuery<TResult, TParams> {
   }
 }
 
-const sql = <TResult, TParams>(stringsArray: TemplateStringsArray) => (
-  new TaggedQuery<TResult, TParams>(stringsArray[0])
+interface ITypePair {
+  params: any;
+  result: any;
+}
+
+const sql = <TTypePair extends ITypePair>(stringsArray: TemplateStringsArray) => (
+  new TaggedQuery<TTypePair>(stringsArray[0])
 );
 
 export default sql;

--- a/tslint.json
+++ b/tslint.json
@@ -10,5 +10,10 @@
     "arrow-parens": false,
     "max-line-length": false
   },
-  "rulesDirectory": []
+  "rulesDirectory": [],
+  "linterOptions": {
+    "exclude": [
+      "**/*types.ts"
+    ]
+  }
 }


### PR DESCRIPTION
Make `sql` tag to expect one generic parameter instead of two:
```diff
- export const selectUserIds = sql<
-   ISelectUserIdsResult, ISelectUserIdsParams
-   >`select id from users where id = $id and age = $age`;
- `;
+ export const selectUserIds =
+  sql<ISelectUserIdsQuery>`select id from users where id = $id and age = $age`;
```