### PR TITLE
Implement postgres types for JSON, timestamps, and bytes

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -4,6 +4,26 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@pgtyped/query": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@pgtyped/query/-/query-0.6.0.tgz",
+			"integrity": "sha512-HDwgiMAzTUDU4EvwGryMj+m3k4SU554xkPrhkX7qSdxHktlumhbiCwzgs4JOoPCZyMH0tn0PSUCC7Kna7DWs8g==",
+			"requires": {
+				"@pgtyped/wire": "^0.6.0",
+				"@types/debug": "^4.1.4",
+				"antlr4ts": "^0.5.0-alpha.3",
+				"debug": "^4.1.1"
+			}
+		},
+		"@pgtyped/wire": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@pgtyped/wire/-/wire-0.6.0.tgz",
+			"integrity": "sha512-pqG8JM9gR0pI3bBeHfWHJwJhT/Yo6b+pIbC5caZ2FPVNav6rESVbd5NiiUE9W5XqIwnr/mZv/yi3VuqcfDgDRA==",
+			"requires": {
+				"@types/debug": "^4.1.4",
+				"debug": "^4.1.1"
+			}
+		},
 		"@types/camel-case": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@types/camel-case/-/camel-case-1.2.1.tgz",
@@ -20,8 +40,7 @@
 		"@types/debug": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
-			"dev": true
+			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -76,6 +95,11 @@
 				"@types/color-name": "^1.1.1",
 				"color-convert": "^2.0.1"
 			}
+		},
+		"antlr4ts": {
+			"version": "0.5.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
+			"integrity": "sha512-La89tKkGcHFIVuruv4Bm1esc3zLmES2NOTEwwNS1pudz+zx/0FNqQeUu9p48i9/QHKPVqjN87LB+q3buTg7oDQ=="
 		},
 		"anymatch": {
 			"version": "3.1.1",

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,183 @@
+export type Type =
+  | NamedType
+  | ImportedType
+  | AliasedType;
+
+export interface NamedType {
+  name: string
+  definition?: string
+}
+
+export interface ImportedType extends NamedType {
+  from: string
+}
+
+export interface AliasedType extends NamedType {
+  definition: string
+}
+
+function isImport(typ: Type): typ is ImportedType {
+  return 'from' in typ;
+}
+
+function isAlias(typ: Type): typ is AliasedType {
+  return 'definition' in typ;
+}
+
+// Default types
+const String: Type = { name: 'string' };
+const Number: Type = { name: 'number' };
+const Boolean: Type = { name: 'boolean' };
+const Date: Type = { name: 'Date' };
+const Bytes: Type = { name: 'Buffer' };
+const Json: Type = {
+  name: 'Json',
+  definition: 'null | boolean | number | string | Json[] | { [key: string]: Json }',
+};
+
+export const DefaultTypeMapping = Object.freeze({
+  // Integer types
+  int2: Number,
+  int4: Number,
+  int8: Number,
+  smallint: Number,
+  int: Number,
+  bigint: Number,
+
+  // Precision types
+  real: Number,
+  float4: Number,
+  float: Number,
+  float8: Number,
+  numeric: Number,
+  decimal: Number,
+
+  // Serial types
+  smallserial: Number,
+  serial: Number,
+  bigserial: Number,
+
+  // Common string types
+  uuid: String,
+  text: String,
+  varchar: String,
+  char: String,
+
+  // Bool types
+  bit: Boolean, // TODO: better bit array support
+  bool: Boolean,
+  boolean: Boolean,
+
+  // Dates and times
+  date: Date,
+  timestamp: Date,
+  timestamptz: Date,
+  time: Date,
+  timetz: Date,
+
+  // Extra types
+  money: Number,
+
+  // JSON types
+  json: Json,
+  jsonb: Json,
+
+  // Bytes
+  bytea: Bytes,
+});
+
+export type BuiltinTypes = keyof typeof DefaultTypeMapping;
+
+export type TypeMapping = {
+  [postgresType in BuiltinTypes]: Type;
+};
+
+export function TypeMapping(overrides?: Partial<TypeMapping>): TypeMapping {
+  return { ...DefaultTypeMapping, ...overrides };
+}
+
+function declareAlias(name: string, definition: string): string {
+  return `export type ${name} = ${definition};\n`;
+}
+
+function declareImport(names: string[], from: string): string {
+  return `import { ${names.join(', ')} } from '${from}';\n`;
+}
+
+/** Wraps a TypeMapping to track which types have been used, to accumulate errors,
+ * and emit necessary type definitions. */
+export class TypeAllocator {
+  errors: Error[] = [];
+  // from -> names
+  imports: { [k: string]: string[] } = {};
+  // name -> definition (if any)
+  types: { [k: string]: string } = {};
+
+  constructor(
+    private mapping: TypeMapping,
+    private allowUnmappedTypes?: boolean,
+  ) {
+  }
+
+  isMappedType(name: string): name is BuiltinTypes {
+    return name in this.mapping;
+  }
+
+  /** Lookup a database-provided type name in the allocator's map */
+  use(typeNameOrType: string | Type): string {
+    let typ: Type;
+
+    if (typeof typeNameOrType == 'string') {
+      if (!this.isMappedType(typeNameOrType)) {
+        if (this.allowUnmappedTypes) {
+          return typeNameOrType;
+        }
+        this.errors.push(
+          new Error(`Postgres type '${typeNameOrType}' is not supported by mapping`),
+        );
+        return 'never';
+      }
+      typ = this.mapping[typeNameOrType];
+    } else {
+      typ = typeNameOrType;
+    }
+
+    // If first time we have seen this type then track its use
+    if (!(typ.name in this.types)) {
+      this.types[typ.name] = typ.definition ? typ.definition : '';
+
+      if (isImport(typ)) {
+        if (typ.from in this.imports) {
+          // Merge imports with same path
+          this.imports[typ.from].push(typ.name);
+        } else {
+          this.imports[typ.from] = [typ.name];
+        }
+      }
+    }
+
+    return typ.name;
+  }
+
+  /** Emit a typescript definition for all types that have been used */
+  declaration(): string {
+    const imports = Object.entries(this.imports)
+      .map(([from, names]) => declareImport(names, from))
+      .join('\n');
+
+    const aliases = Object.entries(this.types)
+      .filter(([_, definition]) => definition)
+      .map(([name, definition]) => declareAlias(name, definition))
+      .join('\n');
+
+    return [imports, aliases].filter(s => s).join('\n');
+  }
+
+  async check() {
+    if (this.errors.length > 0) {
+      throw new Error(
+        `Errors with types used in generation:\n\t${this.errors.join('\n\t')}`,
+      );
+    }
+  }
+}

--- a/packages/example/docker-compose.yml
+++ b/packages/example/docker-compose.yml
@@ -17,5 +17,6 @@ services:
     build: .
     volumes:
       - ../../:/app
+    restart: always
     links:
       - db

--- a/packages/example/sql/schema.sql
+++ b/packages/example/sql/schema.sql
@@ -8,6 +8,12 @@ CREATE TABLE users (
   registration_date DATE NOT NULL DEFAULT CURRENT_DATE
 );
 
+CREATE TABLE notifications (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users,
+  payload jsonb NOT NULL
+);
+
 CREATE TABLE authors (
   id SERIAL PRIMARY KEY,
   first_name TEXT,
@@ -28,22 +34,38 @@ CREATE TABLE book_comments (
   body TEXT
 );
 
-INSERT INTO users (email, user_name, first_name, last_name, age) VALUES
-('alex.doe@example.com', 'alexd', 'Alex', 'Doe', 35),
-('jane.holmes@example.com', 'jane67', 'Jane', 'Holmes', 23),
-('andrewjackson@example.com', 'ajack9', 'Andrew', 'Jackson', 19);
+INSERT INTO users (email, user_name, first_name, last_name, age)
+VALUES ('alex.doe@example.com', 'alexd', 'Alex', 'Doe', 35),
+       ('jane.holmes@example.com', 'jane67', 'Jane', 'Holmes', 23),
+       ('andrewjackson@example.com', 'ajack9', 'Andrew', 'Jackson', 19);
 
-INSERT INTO authors (first_name, last_name) VALUES
-('Nassim', 'Taleb'),
-('Carl', 'Sagan'),
-('Bertolt', 'Brecht');
+INSERT INTO notifications (user_id, payload)
+VALUES (1, '{
+  "message": "You have new frogs",
+  "num_frogs": 2,
+  "history": [
+    {
+      "event": "NewFrog",
+      "timestamp": "2020-05-05T17:12:25+01:00"
+    },
+    {
+      "event": "NewFrog",
+      "timestamp": "2020-05-05T17:13:04+01:00"
+    }
+  ]
+}');
 
-INSERT INTO books (rank, name, author_id) VALUES
-(1, 'Black Swan', 1),
-(4, 'The Dragons Of Eden', 2),
-(2, 'Mysteries of a Barbershop', 3),
-(3, 'In the Jungle of Cities', 3);
+INSERT INTO authors (first_name, last_name)
+VALUES ('Nassim', 'Taleb'),
+       ('Carl', 'Sagan'),
+       ('Bertolt', 'Brecht');
 
-INSERT INTO book_comments (user_id, book_id, body) VALUES
-(1, 1, 'Fantastic read, recommend it!'),
-(1, 2, 'Did not like it, expected much more...');
+INSERT INTO books (rank, name, author_id)
+VALUES (1, 'Black Swan', 1),
+       (4, 'The Dragons Of Eden', 2),
+       (2, 'Mysteries of a Barbershop', 3),
+       (3, 'In the Jungle of Cities', 3);
+
+INSERT INTO book_comments (user_id, book_id, body)
+VALUES (1, 1, 'Fantastic read, recommend it!'),
+       (1, 2, 'Did not like it, expected much more...');

--- a/packages/example/src/books/books.queries.ts
+++ b/packages/example/src/books/books.queries.ts
@@ -1,6 +1,5 @@
 /** Types generated for queries found in "src/books/books.sql" */
-
-import { PreparedQuery } from "@pgtyped/query";
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'FindBookById' parameters type */
 export interface IFindBookByIdParams {

--- a/packages/example/src/comments/comments.queries.ts
+++ b/packages/example/src/comments/comments.queries.ts
@@ -1,6 +1,5 @@
 /** Types generated for queries found in "src/comments/comments.sql" */
-
-import { PreparedQuery } from "@pgtyped/query";
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'GetAllComments' parameters type */
 export interface IGetAllCommentsParams {

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -1,6 +1,9 @@
 import { Client, QueryResult } from 'pg';
 import { insertBooks, getBooksByAuthorName } from './books/books.queries';
-
+import {
+  sendNotifications,
+  thresholdFrogs,
+} from './notifications/notifications.queries';
 // tslint:disable:no-console
 
 export const client = new Client({
@@ -8,7 +11,7 @@ export const client = new Client({
   user: 'test',
   password: 'example',
   database: 'test',
-  port: 5433,
+  port: 5432,
 });
 
 async function main() {
@@ -34,6 +37,16 @@ async function main() {
     client,
   );
   console.log(`Inserted book ID: ${insertedBookId}`);
+
+  await sendNotifications.run(
+    { notifications: [{ user_id: 2, payload: { num_frogs: 82 } }] },
+    client,
+  );
+
+  const notifications = await thresholdFrogs.run({ numFrogs: 80 }, client);
+
+  console.log(notifications);
+
   await client.end();
 }
 

--- a/packages/example/src/notifications/notifications.queries.ts
+++ b/packages/example/src/notifications/notifications.queries.ts
@@ -1,0 +1,98 @@
+/** Types generated for queries found in "src/notifications/notifications.sql" */
+import { PreparedQuery } from '@pgtyped/query';
+
+export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+
+/** 'GetNotifications' parameters type */
+export interface IGetNotificationsParams {
+  userId: number | null | void;
+}
+
+/** 'GetNotifications' return type */
+export interface IGetNotificationsResult {
+  id: number;
+  user_id: number | null;
+  payload: Json;
+}
+
+/** 'GetNotifications' query type */
+export interface IGetNotificationsQuery {
+  params: IGetNotificationsParams;
+  result: IGetNotificationsResult;
+}
+
+const getNotificationsIR: any = {"name":"GetNotifications","params":[{"name":"userId","transform":{"type":"scalar"},"codeRefs":{"used":{"a":74,"b":79,"line":4,"col":17}}}],"usedParamSet":{"userId":true},"statement":{"body":"SELECT *\nFROM notifications\nWHERE user_id = :userId","loc":{"a":29,"b":79,"line":2,"col":0}}};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT *
+ * FROM notifications
+ * WHERE user_id = :userId
+ * ```
+ */
+export const getNotifications = new PreparedQuery<IGetNotificationsParams,IGetNotificationsResult>(getNotificationsIR);
+
+
+/** 'SendNotifications' parameters type */
+export interface ISendNotificationsParams {
+  notifications: Array<{
+    user_id: number,
+    payload: Json
+  }>;
+}
+
+/** 'SendNotifications' return type */
+export interface ISendNotificationsResult {
+  notification_id: number;
+}
+
+/** 'SendNotifications' query type */
+export interface ISendNotificationsQuery {
+  params: ISendNotificationsParams;
+  result: ISendNotificationsResult;
+}
+
+const sendNotificationsIR: any = {"name":"SendNotifications","params":[{"name":"notifications","codeRefs":{"defined":{"a":121,"b":133,"line":8,"col":9},"used":{"a":218,"b":230,"line":11,"col":8}},"transform":{"type":"pick_array_spread","keys":["user_id","payload"]}}],"usedParamSet":{"notifications":true},"statement":{"body":"INSERT INTO notifications (user_id, payload)\nVALUES :notifications RETURNING id as notification_id","loc":{"a":165,"b":262,"line":10,"col":0}}};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO notifications (user_id, payload)
+ * VALUES :notifications RETURNING id as notification_id
+ * ```
+ */
+export const sendNotifications = new PreparedQuery<ISendNotificationsParams,ISendNotificationsResult>(sendNotificationsIR);
+
+
+/** 'ThresholdFrogs' parameters type */
+export interface IThresholdFrogsParams {
+  numFrogs: number | null | void;
+}
+
+/** 'ThresholdFrogs' return type */
+export interface IThresholdFrogsResult {
+  user_name: string;
+  payload: Json;
+}
+
+/** 'ThresholdFrogs' query type */
+export interface IThresholdFrogsQuery {
+  params: IThresholdFrogsParams;
+  result: IThresholdFrogsResult;
+}
+
+const thresholdFrogsIR: any = {"name":"ThresholdFrogs","params":[{"name":"numFrogs","transform":{"type":"scalar"},"codeRefs":{"used":{"a":431,"b":438,"line":19,"col":46}}}],"usedParamSet":{"numFrogs":true},"statement":{"body":"SELECT u.user_name, n.payload\nFROM notifications n\nINNER JOIN users u on n.user_id = u.id\nWHERE CAST (n.payload->'num_frogs' AS int) > :numFrogs","loc":{"a":295,"b":438,"line":16,"col":0}}};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT u.user_name, n.payload
+ * FROM notifications n
+ * INNER JOIN users u on n.user_id = u.id
+ * WHERE CAST (n.payload->'num_frogs' AS int) > :numFrogs
+ * ```
+ */
+export const thresholdFrogs = new PreparedQuery<IThresholdFrogsParams,IThresholdFrogsResult>(thresholdFrogsIR);
+
+

--- a/packages/example/src/notifications/notifications.sql
+++ b/packages/example/src/notifications/notifications.sql
@@ -1,0 +1,20 @@
+/* @name GetNotifications */
+SELECT *
+FROM notifications
+WHERE user_id = :userId;
+
+/*
+  @name SendNotifications
+  @param notifications -> ((user_id, payload)...)
+*/
+INSERT INTO notifications (user_id, payload)
+VALUES :notifications RETURNING id as notification_id;
+
+/*
+  @name ThresholdFrogs
+*/
+SELECT u.user_name, n.payload
+FROM notifications n
+INNER JOIN users u on n.user_id = u.id
+WHERE CAST (n.payload->'num_frogs' AS int) > :numFrogs;
+

--- a/packages/query/package-lock.json
+++ b/packages/query/package-lock.json
@@ -4,6 +4,15 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@pgtyped/wire": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@pgtyped/wire/-/wire-0.6.0.tgz",
+			"integrity": "sha512-pqG8JM9gR0pI3bBeHfWHJwJhT/Yo6b+pIbC5caZ2FPVNav6rESVbd5NiiUE9W5XqIwnr/mZv/yi3VuqcfDgDRA==",
+			"requires": {
+				"@types/debug": "^4.1.4",
+				"debug": "^4.1.1"
+			}
+		},
 		"@types/debug": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",

--- a/packages/query/src/actions.ts
+++ b/packages/query/src/actions.ts
@@ -94,7 +94,7 @@ export async function runQuery(query: string, queue: AsyncQueue) {
   return resultRows;
 }
 
-interface IQueryTypes {
+export interface IQueryTypes {
   paramMetadata: {
     mapping: QueryParam[];
     params: string[];


### PR DESCRIPTION
This only has a basic unit test. I was going to add something to example package just so i could test it. is there anywhere else for an integration test?

I've given a nod to your suggestion that people may want different type aliases with my refactor of the type mapping. Currently this allows you to provide an alternative name and optional definition. I thought it might be useful to allow imports to external types to be dragged in but in some ways it's nice to keep it local.

fixes #45 