### PR TITLE
Implement support for Postgres enums

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,15 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    
     steps:
-    - uses: actions/checkout@v1
-    - name: npm ci
-      run: npm ci
-    - name: Bootstrap packages
-      run: npx lerna bootstrap && npm run build
-    - name: Run tests
-      run: npm test
+      - uses: actions/checkout@v1
+      - name: npm ci
+        run: npm ci
+      - name: Bootstrap packages
+        run: npx lerna bootstrap && npm run build
+      - name: Run tests
+        run: npm test

--- a/docs/annotated-sql.md
+++ b/docs/annotated-sql.md
@@ -24,7 +24,10 @@ PgTyped has a number of requirements for SQL file contents:
 
 ## Parameter expansions
 
-PgTyped supports parameter expansions that help build more complicated queries.  
+You always define parameters by a colon-prefixed token in your query, like `:age`. Ordinary parameters (those that do not need to be expanded and can be directly substituted) do not need any additional annotations within the query comment block.
+
+PgTyped also supports parameter expansions that help build more complicated queries by expanding parameters into their components arrays and fields, which are then spliced into the query.
+
 For example, a typical insert query looks like this:
 
 ```sql
@@ -36,7 +39,7 @@ INSERT INTO book_comments (user_id, body)
 VALUES :comments;
 ```
 
-Here `comments -> ((userId, commentBody)...)` is a parameter expansion.
+Here `comments -> ((userId, commentBody)...)` is a parameter expansion that instructs pgtyped to expand `comments` into an array of objects with each object having a field `userId` and `commentBody`.
 
 A query can also contain multiple expansions if needed:
 ```sql

--- a/packages/cli/src/generator.test.ts
+++ b/packages/cli/src/generator.test.ts
@@ -18,7 +18,7 @@ describe('query-to-interface translation (SQL)', () => {
         {
           returnName: 'payload',
           columnName: 'payload',
-          typeName: 'json',
+          type: 'json',
           nullable: false,
         },
       ],
@@ -78,19 +78,19 @@ export interface IGetNotificationsQuery {
         {
           returnName: 'id',
           columnName: 'id',
-          typeName: 'uuid',
+          type: 'uuid',
           nullable: false,
         },
         {
           returnName: 'name',
           columnName: 'name',
-          typeName: 'text',
+          type: 'text',
           nullable: false,
         },
         {
           returnName: 'bote',
           columnName: 'note',
-          typeName: 'text',
+          type: 'text',
           nullable: true,
         },
       ],
@@ -145,28 +145,28 @@ export interface IDeleteUsersQuery {
 
 test('query-to-interface translation (TS)', async () => {
   const query = `
-      delete
-      from users *
-      where name = :userName and id = :userId and note = :userNote returning id, id, name, note as bote;
+    DELETE
+      FROM users *
+     WHERE NAME = :userName AND id = :userId AND note = :userNote RETURNING id, id, NAME, note AS bote;
   `;
   const mockTypes: IQueryTypes = {
     returnTypes: [
       {
         returnName: 'id',
         columnName: 'id',
-        typeName: 'uuid',
+        type: 'uuid',
         nullable: false,
       },
       {
         returnName: 'name',
         columnName: 'name',
-        typeName: 'text',
+        type: 'text',
         nullable: false,
       },
       {
         returnName: 'bote',
         columnName: 'note',
-        typeName: 'text',
+        type: 'text',
         nullable: true,
       },
     ],

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -83,8 +83,8 @@ export async function queryToTypeDeclarations(
   const returnFieldTypes: IField[] = [];
   const paramFieldTypes: IField[] = [];
 
-  returnTypes.forEach(({ returnName, typeName, nullable }) => {
-    let tsTypeName = types.use(typeName);
+  returnTypes.forEach(({ returnName, type, nullable }) => {
+    let tsTypeName = types.use(type);
     if (nullable) {
       tsTypeName += ' | null';
     }
@@ -126,8 +126,11 @@ export async function queryToTypeDeclarations(
     }
   }
 
-  // TODO: revisit as part of error handling task
-  // await types.check();
+  // TypeAllocator errors are currently considered non-fatal since a `never`
+  // type is emitted which can be caught later when compiling the generated
+  // code
+  // tslint:disable-next-line:no-console
+  types.errors.forEach((err) => console.log(err));
 
   const resultInterfaceName = `I${interfaceName}Result`;
   const returnTypesInterface =

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -96,8 +96,9 @@ class FileProcessor {
 
   private processQueue = () => {
     if (this.activePromise) {
-      this.activePromise.then(this.onFileProcessed);
-      // TODO: handle promise rejection
+      this.activePromise
+        .then(this.onFileProcessed)
+        .catch((err) => console.log(`Error processing file: ${err.stack}`));
       return;
     }
     const nextJob = this.jobQueue.pop();

--- a/packages/cli/src/types.test.ts
+++ b/packages/cli/src/types.test.ts
@@ -1,0 +1,11 @@
+import { DefaultTypeMapping, TypeAllocator } from './types';
+
+describe('TypeAllocator', () => {
+  test('Allows overrides', () => {
+    const types = new TypeAllocator({
+      ...DefaultTypeMapping,
+      foo: { name: 'bar' },
+    });
+    expect(types.use('foo')).toEqual('bar');
+  });
+});

--- a/packages/example/config.json
+++ b/packages/example/config.json
@@ -2,7 +2,7 @@
   "transforms": [
     {
       "mode": "sql",
-      "include": "**/*.sql",
+      "include": "**/notifications.sql",
       "emitTemplate": "{{dir}}/{{name}}.queries.ts"
     },
     {
@@ -11,11 +11,5 @@
       "emitTemplate": "{{dir}}/{{name}}.types.ts"
     }
   ],
-  "srcDir": "./src/",
-  "db": {
-    "host": "db",
-    "user": "test",
-    "dbName": "test",
-    "password": "example"
-  }
+  "srcDir": "./src/"
 }

--- a/packages/example/config.json
+++ b/packages/example/config.json
@@ -2,7 +2,7 @@
   "transforms": [
     {
       "mode": "sql",
-      "include": "**/notifications.sql",
+      "include": "**/*.sql",
       "emitTemplate": "{{dir}}/{{name}}.queries.ts"
     },
     {
@@ -11,5 +11,11 @@
       "emitTemplate": "{{dir}}/{{name}}.types.ts"
     }
   ],
-  "srcDir": "./src/"
+  "srcDir": "./src/",
+  "db": {
+    "host": "127.0.0.1",
+    "user": "postgres",
+    "dbName": "postgres",
+    "password": "password"
+  }
 }

--- a/packages/example/docker-compose.yml
+++ b/packages/example/docker-compose.yml
@@ -15,8 +15,13 @@ services:
 
   app:
     build: .
+    environment:
+      PGHOST: db
+      PGUSER: test
+      PGDATABASE: test
+      PGPASSWORD: example
     volumes:
       - ../../:/app
-    restart: always
+    restart: on-failure
     links:
       - db

--- a/packages/example/docker-compose.yml
+++ b/packages/example/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     image: postgres:12-alpine
     restart: always
     environment:
-      POSTGRES_USER: test
-      POSTGRES_PASSWORD: example
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
     ports:
       - "5432:5432"
     volumes:
@@ -17,9 +17,9 @@ services:
     build: .
     environment:
       PGHOST: db
-      PGUSER: test
-      PGDATABASE: test
-      PGPASSWORD: example
+      PGUSER: postgres
+      PGDATABASE: postgres
+      PGPASSWORD: password
     volumes:
       - ../../:/app
     restart: on-failure

--- a/packages/example/package-lock.json
+++ b/packages/example/package-lock.json
@@ -4,10 +4,74 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@pgtyped/cli": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@pgtyped/cli/-/cli-0.6.1.tgz",
+			"integrity": "sha512-3eBnt0fkEEsDIQxrEbFQJoQA1vHZAmg6HcWRD8wfH8wwYpqGd4CZ0qDJfiDZwWfgJPmc1Mkh8coRCEcXSkBfqA==",
+			"requires": {
+				"@pgtyped/query": "^0.6.0",
+				"@types/camel-case": "^1.2.1",
+				"@types/nunjucks": "^3.1.3",
+				"camel-case": "^4.1.1",
+				"chalk": "^4.0.0",
+				"chokidar": "^3.3.1",
+				"debug": "^4.1.1",
+				"fp-ts": "^2.5.3",
+				"glob": "^7.1.6",
+				"io-ts": "^2.1.2",
+				"io-ts-reporters": "^1.0.0",
+				"minimist": "^1.2.5",
+				"nunjucks": "3.2.1",
+				"pascal-case": "^3.1.1"
+			}
+		},
+		"@pgtyped/query": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@pgtyped/query/-/query-0.6.0.tgz",
+			"integrity": "sha512-HDwgiMAzTUDU4EvwGryMj+m3k4SU554xkPrhkX7qSdxHktlumhbiCwzgs4JOoPCZyMH0tn0PSUCC7Kna7DWs8g==",
+			"requires": {
+				"@pgtyped/wire": "^0.6.0",
+				"@types/debug": "^4.1.4",
+				"antlr4ts": "^0.5.0-alpha.3",
+				"debug": "^4.1.1"
+			}
+		},
+		"@pgtyped/wire": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@pgtyped/wire/-/wire-0.6.0.tgz",
+			"integrity": "sha512-pqG8JM9gR0pI3bBeHfWHJwJhT/Yo6b+pIbC5caZ2FPVNav6rESVbd5NiiUE9W5XqIwnr/mZv/yi3VuqcfDgDRA==",
+			"requires": {
+				"@types/debug": "^4.1.4",
+				"debug": "^4.1.1"
+			}
+		},
+		"@types/camel-case": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/camel-case/-/camel-case-1.2.1.tgz",
+			"integrity": "sha1-x7qDWh3KXvgrQOJNenqAe7n8Dkw=",
+			"requires": {
+				"camel-case": "*"
+			}
+		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
+		"@types/debug": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+		},
 		"@types/node": {
 			"version": "13.9.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
 			"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
+		},
+		"@types/nunjucks": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.1.3.tgz",
+			"integrity": "sha512-42IiIIBdoB7ZDwCVhCWYT4fMCj+4TeacuVgh7xyT2du5EhkpA+OFeeDdYTFCUt1MrHb8Aw7ZqFvr8s1bwP9l8w=="
 		},
 		"@types/pg": {
 			"version": "7.14.3",
@@ -23,15 +87,316 @@
 			"resolved": "https://registry.npmjs.org/@types/pg-types/-/pg-types-1.11.5.tgz",
 			"integrity": "sha512-L8ogeT6vDzT1vxlW3KITTCt+BVXXVkLXfZ/XNm6UqbcJgxf+KPO7yjWx7dQQE8RW07KopL10x2gNMs41+IkMGQ=="
 		},
+		"a-sync-waterfall": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+			"integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+		},
+		"ansi-styles": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+			"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+			"requires": {
+				"@types/color-name": "^1.1.1",
+				"color-convert": "^2.0.1"
+			}
+		},
+		"antlr4ts": {
+			"version": "0.5.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
+			"integrity": "sha512-La89tKkGcHFIVuruv4Bm1esc3zLmES2NOTEwwNS1pudz+zx/0FNqQeUu9p48i9/QHKPVqjN87LB+q3buTg7oDQ=="
+		},
+		"anymatch": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+			"requires": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			}
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"binary-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"requires": {
+				"fill-range": "^7.0.1"
+			}
+		},
 		"buffer-writer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
 			"integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
 		},
+		"camel-case": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+			"integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+			"requires": {
+				"pascal-case": "^3.1.1",
+				"tslib": "^1.10.0"
+			}
+		},
+		"chalk": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+			"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			}
+		},
+		"chokidar": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+			"integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+			"requires": {
+				"anymatch": "~3.1.1",
+				"braces": "~3.0.2",
+				"fsevents": "~2.1.2",
+				"glob-parent": "~5.1.0",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.4.0"
+			}
+		},
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"requires": {
+				"color-name": "~1.1.4"
+			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+		},
+		"commander": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+			"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
+		"fill-range": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"requires": {
+				"to-regex-range": "^5.0.1"
+			}
+		},
+		"fp-ts": {
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.5.4.tgz",
+			"integrity": "sha512-cZlLeEneRYypc2dOzB9h8+bd9mQhJVyt2g0Dny2gKR7uWNgA4EmLSJyguLYsTU44nJSSG9EjurUalEc0wQqeKw=="
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fsevents": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+			"optional": true
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-parent": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+			"requires": {
+				"is-glob": "^4.0.1"
+			}
+		},
+		"has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"io-ts": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.2.tgz",
+			"integrity": "sha512-cXXIL4CR5/sWfKw/Ssc/cbZJGG13J4pJv9/RN6SlWJyh+foAPEUE0I9sWTX1kG24dvhiCM9fpO4F+2AsP+WzaQ=="
+		},
+		"io-ts-reporters": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/io-ts-reporters/-/io-ts-reporters-1.0.0.tgz",
+			"integrity": "sha512-jjMvTnFYYxX3ue3cajmqCAf7sM4+lFvaaUuAL+otJv2DE+WDxYvQeCcUYveoq37rVSftJHZBEOrnvz3x0VdRXA==",
+			"requires": {
+				"fp-ts": "^2.0.2",
+				"io-ts": "^2.0.0"
+			}
+		},
+		"is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"requires": {
+				"binary-extensions": "^2.0.0"
+			}
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+		},
+		"is-glob": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
+		},
+		"is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+		},
+		"lower-case": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+			"integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+			"requires": {
+				"tslib": "^1.10.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"no-case": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+			"integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+			"requires": {
+				"lower-case": "^2.0.1",
+				"tslib": "^1.10.0"
+			}
+		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+		},
+		"nunjucks": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.1.tgz",
+			"integrity": "sha512-LYlVuC1ZNSalQQkLNNPvcgPt2M9FTY9bs39mTCuFXtqh7jWbYzhDlmz2M6onPiXEhdZo+b9anRhc+uBGuJZ2bQ==",
+			"requires": {
+				"a-sync-waterfall": "^1.0.0",
+				"asap": "^2.0.3",
+				"chokidar": "^3.3.0",
+				"commander": "^3.0.2"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
 		"packet-reader": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
 			"integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+		},
+		"pascal-case": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+			"integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+			"requires": {
+				"no-case": "^3.0.3",
+				"tslib": "^1.10.0"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"pg": {
 			"version": "8.0.3",
@@ -88,6 +453,11 @@
 				"split": "^1.0.0"
 			}
 		},
+		"picomatch": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+		},
 		"postgres-array": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -111,6 +481,14 @@
 				"xtend": "^4.0.0"
 			}
 		},
+		"readdirp": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+			"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+			"requires": {
+				"picomatch": "^2.2.1"
+			}
+		},
 		"semver": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
@@ -124,15 +502,41 @@
 				"through": "2"
 			}
 		},
+		"supports-color": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+			"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+			"requires": {
+				"has-flag": "^4.0.0"
+			}
+		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
+		"to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"requires": {
+				"is-number": "^7.0.0"
+			}
+		},
+		"tslib": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
+			"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+		},
 		"typescript": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
 			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/packages/example/sql/schema.sql
+++ b/packages/example/sql/schema.sql
@@ -8,10 +8,13 @@ CREATE TABLE users (
   registration_date DATE NOT NULL DEFAULT CURRENT_DATE
 );
 
+CREATE TYPE notification_type AS ENUM ('notification', 'reminder', 'deadline');
+
 CREATE TABLE notifications (
   id SERIAL PRIMARY KEY,
   user_id INTEGER REFERENCES users,
-  payload jsonb NOT NULL
+  payload jsonb NOT NULL,
+  type notification_type NOT NULL DEFAULT 'notification'
 );
 
 CREATE TABLE authors (

--- a/packages/example/src/books/books.queries.ts
+++ b/packages/example/src/books/books.queries.ts
@@ -1,4 +1,4 @@
-/** Types generated for queries found in "src/books/books.sql" */
+/** Types generated for queries found in "./src/books/books.sql" */
 import { PreparedQuery } from '@pgtyped/query';
 
 /** 'FindBookById' parameters type */

--- a/packages/example/src/comments/comments.queries.ts
+++ b/packages/example/src/comments/comments.queries.ts
@@ -1,4 +1,4 @@
-/** Types generated for queries found in "src/comments/comments.sql" */
+/** Types generated for queries found in "./src/comments/comments.sql" */
 import { PreparedQuery } from '@pgtyped/query';
 
 /** 'GetAllComments' parameters type */

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -1,6 +1,7 @@
 import { Client, QueryResult } from 'pg';
 import { insertBooks, getBooksByAuthorName } from './books/books.queries';
 import {
+  notification_type,
   sendNotifications,
   thresholdFrogs,
 } from './notifications/notifications.queries';
@@ -39,7 +40,15 @@ async function main() {
   console.log(`Inserted book ID: ${insertedBookId}`);
 
   await sendNotifications.run(
-    { notifications: [{ user_id: 2, payload: { num_frogs: 82 } }] },
+    {
+      notifications: [
+        {
+          user_id: 2,
+          payload: { num_frogs: 82 },
+          type: notification_type.reminder,
+        },
+      ],
+    },
     client,
   );
 

--- a/packages/example/src/notifications/notifications.queries.ts
+++ b/packages/example/src/notifications/notifications.queries.ts
@@ -1,44 +1,19 @@
-/** Types generated for queries found in "src/notifications/notifications.sql" */
+/** Types generated for queries found in "./src/notifications/notifications.sql" */
 import { PreparedQuery } from '@pgtyped/query';
 
+export const enum notification_type {
+  notification = 'notification',
+  reminder = 'reminder',
+  deadline = 'deadline',
+}
 export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
-
-/** 'GetNotifications' parameters type */
-export interface IGetNotificationsParams {
-  userId: number | null | void;
-}
-
-/** 'GetNotifications' return type */
-export interface IGetNotificationsResult {
-  id: number;
-  user_id: number | null;
-  payload: Json;
-}
-
-/** 'GetNotifications' query type */
-export interface IGetNotificationsQuery {
-  params: IGetNotificationsParams;
-  result: IGetNotificationsResult;
-}
-
-const getNotificationsIR: any = {"name":"GetNotifications","params":[{"name":"userId","transform":{"type":"scalar"},"codeRefs":{"used":{"a":74,"b":79,"line":4,"col":17}}}],"usedParamSet":{"userId":true},"statement":{"body":"SELECT *\nFROM notifications\nWHERE user_id = :userId","loc":{"a":29,"b":79,"line":2,"col":0}}};
-
-/**
- * Query generated from SQL:
- * ```
- * SELECT *
- * FROM notifications
- * WHERE user_id = :userId
- * ```
- */
-export const getNotifications = new PreparedQuery<IGetNotificationsParams,IGetNotificationsResult>(getNotificationsIR);
-
 
 /** 'SendNotifications' parameters type */
 export interface ISendNotificationsParams {
   notifications: Array<{
     user_id: number,
-    payload: Json
+    payload: Json,
+    type: notification_type
   }>;
 }
 
@@ -53,16 +28,48 @@ export interface ISendNotificationsQuery {
   result: ISendNotificationsResult;
 }
 
-const sendNotificationsIR: any = {"name":"SendNotifications","params":[{"name":"notifications","codeRefs":{"defined":{"a":121,"b":133,"line":8,"col":9},"used":{"a":218,"b":230,"line":11,"col":8}},"transform":{"type":"pick_array_spread","keys":["user_id","payload"]}}],"usedParamSet":{"notifications":true},"statement":{"body":"INSERT INTO notifications (user_id, payload)\nVALUES :notifications RETURNING id as notification_id","loc":{"a":165,"b":262,"line":10,"col":0}}};
+const sendNotificationsIR: any = {"name":"SendNotifications","params":[{"name":"notifications","codeRefs":{"defined":{"a":38,"b":50,"line":3,"col":9},"used":{"a":147,"b":159,"line":6,"col":8}},"transform":{"type":"pick_array_spread","keys":["user_id","payload","type"]}}],"usedParamSet":{"notifications":true},"statement":{"body":"INSERT INTO notifications (user_id, payload, type)\nVALUES :notifications RETURNING id as notification_id","loc":{"a":88,"b":191,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
  * ```
- * INSERT INTO notifications (user_id, payload)
+ * INSERT INTO notifications (user_id, payload, type)
  * VALUES :notifications RETURNING id as notification_id
  * ```
  */
 export const sendNotifications = new PreparedQuery<ISendNotificationsParams,ISendNotificationsResult>(sendNotificationsIR);
+
+
+/** 'GetNotifications' parameters type */
+export interface IGetNotificationsParams {
+  userId: number | null | void;
+}
+
+/** 'GetNotifications' return type */
+export interface IGetNotificationsResult {
+  id: number;
+  user_id: number | null;
+  payload: Json;
+  type: notification_type;
+}
+
+/** 'GetNotifications' query type */
+export interface IGetNotificationsQuery {
+  params: IGetNotificationsParams;
+  result: IGetNotificationsResult;
+}
+
+const getNotificationsIR: any = {"name":"GetNotifications","params":[{"name":"userId","transform":{"type":"scalar"},"codeRefs":{"used":{"a":272,"b":277,"line":11,"col":18}}}],"usedParamSet":{"userId":true},"statement":{"body":"SELECT *\n  FROM notifications\n WHERE user_id = :userId","loc":{"a":224,"b":277,"line":9,"col":0}}};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT *
+ *   FROM notifications
+ *  WHERE user_id = :userId
+ * ```
+ */
+export const getNotifications = new PreparedQuery<IGetNotificationsParams,IGetNotificationsResult>(getNotificationsIR);
 
 
 /** 'ThresholdFrogs' parameters type */
@@ -74,6 +81,7 @@ export interface IThresholdFrogsParams {
 export interface IThresholdFrogsResult {
   user_name: string;
   payload: Json;
+  type: notification_type;
 }
 
 /** 'ThresholdFrogs' query type */
@@ -82,12 +90,12 @@ export interface IThresholdFrogsQuery {
   result: IThresholdFrogsResult;
 }
 
-const thresholdFrogsIR: any = {"name":"ThresholdFrogs","params":[{"name":"numFrogs","transform":{"type":"scalar"},"codeRefs":{"used":{"a":431,"b":438,"line":19,"col":46}}}],"usedParamSet":{"numFrogs":true},"statement":{"body":"SELECT u.user_name, n.payload\nFROM notifications n\nINNER JOIN users u on n.user_id = u.id\nWHERE CAST (n.payload->'num_frogs' AS int) > :numFrogs","loc":{"a":295,"b":438,"line":16,"col":0}}};
+const thresholdFrogsIR: any = {"name":"ThresholdFrogs","params":[{"name":"numFrogs","transform":{"type":"scalar"},"codeRefs":{"used":{"a":455,"b":462,"line":20,"col":46}}}],"usedParamSet":{"numFrogs":true},"statement":{"body":"SELECT u.user_name, n.payload, n.type\nFROM notifications n\nINNER JOIN users u on n.user_id = u.id\nWHERE CAST (n.payload->'num_frogs' AS int) > :numFrogs","loc":{"a":311,"b":462,"line":17,"col":0}}};
 
 /**
  * Query generated from SQL:
  * ```
- * SELECT u.user_name, n.payload
+ * SELECT u.user_name, n.payload, n.type
  * FROM notifications n
  * INNER JOIN users u on n.user_id = u.id
  * WHERE CAST (n.payload->'num_frogs' AS int) > :numFrogs

--- a/packages/example/src/notifications/notifications.sql
+++ b/packages/example/src/notifications/notifications.sql
@@ -1,19 +1,20 @@
-/* @name GetNotifications */
-SELECT *
-FROM notifications
-WHERE user_id = :userId;
-
 /*
   @name SendNotifications
-  @param notifications -> ((user_id, payload)...)
+  @param notifications -> ((user_id, payload, type)...)
 */
-INSERT INTO notifications (user_id, payload)
+INSERT INTO notifications (user_id, payload, type)
 VALUES :notifications RETURNING id as notification_id;
+
+/* @name GetNotifications */
+SELECT *
+  FROM notifications
+ WHERE user_id = :userId;
+
 
 /*
   @name ThresholdFrogs
 */
-SELECT u.user_name, n.payload
+SELECT u.user_name, n.payload, n.type
 FROM notifications n
 INNER JOIN users u on n.user_id = u.id
 WHERE CAST (n.payload->'num_frogs' AS int) > :numFrogs;

--- a/packages/example/src/users/sample.types.ts
+++ b/packages/example/src/users/sample.types.ts
@@ -1,4 +1,4 @@
-/** Types generated for queries found in "src/users/sample.ts" */
+/** Types generated for queries found in "./src/users/sample.ts" */
 
 /** 'getUsersWithComments' parameters type */
 export interface IGetUsersWithCommentsParams {

--- a/packages/query/src/__snapshots__/actions.test.ts.snap
+++ b/packages/query/src/__snapshots__/actions.test.ts.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reduce type rows to MappableTypes 1`] = `
+Object {
+  "23": "int4",
+  "25": "text",
+}
+`;
+
+exports[`reduce type rows to MappableTypes 2`] = `
+Object {
+  "16398": Object {
+    "enumValues": Array [
+      "notification",
+      "reminder",
+      "deadline",
+    ],
+    "name": "notification_type",
+  },
+  "23": "int4",
+  "3802": "jsonb",
+}
+`;
+
+exports[`reduce type rows to MappableTypes 3`] = `
+Object {
+  "16398": Object {
+    "enumValues": Array [
+      "notification",
+      "reminder",
+      "deadline",
+    ],
+    "name": "notification_type",
+  },
+  "23": "int4",
+  "3802": "jsonb",
+}
+`;
+
+exports[`reduce type rows to MappableTypes 4`] = `
+Object {
+  "16398": Object {
+    "enumValues": Array [
+      "notification",
+      "reminder",
+      "deadline",
+    ],
+    "name": "notification_type",
+  },
+  "23": "int4",
+  "25": "text",
+  "3802": "jsonb",
+}
+`;
+
+exports[`reduce type rows to MappableTypes 5`] = `
+Object {
+  "1082": "date",
+  "20": "int8",
+  "23": "int4",
+  "25": "text",
+}
+`;

--- a/packages/query/src/actions.test.ts
+++ b/packages/query/src/actions.test.ts
@@ -1,7 +1,166 @@
-import { generateHash } from './actions';
+import { generateHash, reduceTypeRows } from './actions';
 
 test('test postgres md5 hash generation', () => {
   const salt = [0x81, 0xcc, 0x95, 0x8b];
   const result = generateHash('test', 'example', Buffer.from(salt));
   expect(result).toEqual('md5b73f398d18e98f8e2d46a7f1c548dea3');
+});
+
+test('reduce type rows to MappableTypes', () => {
+  expect(
+    reduceTypeRows([
+      {
+        oid: '25',
+        typeName: 'text',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+      {
+        oid: '23',
+        typeName: 'int4',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+    ]),
+  ).toMatchSnapshot();
+
+  expect(
+    reduceTypeRows([
+      {
+        oid: '16398',
+        typeName: 'notification_type',
+        typeKind: 'e',
+        enumLabel: 'notification',
+      },
+      {
+        oid: '16398',
+        typeName: 'notification_type',
+        typeKind: 'e',
+        enumLabel: 'reminder',
+      },
+      {
+        oid: '16398',
+        typeName: 'notification_type',
+        typeKind: 'e',
+        enumLabel: 'deadline',
+      },
+      {
+        oid: '23',
+        typeName: 'int4',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+      {
+        oid: '3802',
+        typeName: 'jsonb',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+    ]),
+  ).toMatchSnapshot();
+
+  expect(
+    reduceTypeRows([
+      {
+        oid: '16398',
+        typeName: 'notification_type',
+        typeKind: 'e',
+        enumLabel: 'notification',
+      },
+      {
+        oid: '16398',
+        typeName: 'notification_type',
+        typeKind: 'e',
+        enumLabel: 'reminder',
+      },
+      {
+        oid: '16398',
+        typeName: 'notification_type',
+        typeKind: 'e',
+        enumLabel: 'deadline',
+      },
+      {
+        oid: '23',
+        typeName: 'int4',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+      {
+        oid: '3802',
+        typeName: 'jsonb',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+    ]),
+  ).toMatchSnapshot();
+
+  expect(
+    reduceTypeRows([
+      {
+        oid: '16398',
+        typeName: 'notification_type',
+        typeKind: 'e',
+        enumLabel: 'notification',
+      },
+      {
+        oid: '16398',
+        typeName: 'notification_type',
+        typeKind: 'e',
+        enumLabel: 'reminder',
+      },
+      {
+        oid: '16398',
+        typeName: 'notification_type',
+        typeKind: 'e',
+        enumLabel: 'deadline',
+      },
+      {
+        oid: '25',
+        typeName: 'text',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+      {
+        oid: '23',
+        typeName: 'int4',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+      {
+        oid: '3802',
+        typeName: 'jsonb',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+    ]),
+  ).toMatchSnapshot();
+
+  expect(
+    reduceTypeRows([
+      {
+        oid: '20',
+        typeName: 'int8',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+      {
+        oid: '25',
+        typeName: 'text',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+      {
+        oid: '1082',
+        typeName: 'date',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+      {
+        oid: '23',
+        typeName: 'int4',
+        typeKind: 'b',
+        enumLabel: '',
+      },
+    ]),
+  ).toMatchSnapshot();
 });

--- a/packages/query/src/type.ts
+++ b/packages/query/src/type.ts
@@ -32,7 +32,7 @@ export function isEnum(typ: MappableType): typ is EnumType {
   return typeof typ !== 'string' && 'enumValues' in typ;
 }
 
-export const enum DatabaseTypeType {
+export const enum DatabaseTypeKind {
   Base = 'b',
   Composite = 'c',
   Domain = 'd',

--- a/packages/query/src/type.ts
+++ b/packages/query/src/type.ts
@@ -1,0 +1,42 @@
+export type Type = NamedType | ImportedType | AliasedType | EnumType;
+// May be a database source type name (string) or a typescript destination type (Type)
+export type MappableType = string | Type;
+
+export interface NamedType {
+  name: string;
+  definition?: string;
+  enumValues?: string[];
+}
+
+export interface ImportedType extends NamedType {
+  from: string;
+}
+
+export interface AliasedType extends NamedType {
+  definition: string;
+}
+
+export interface EnumType extends NamedType {
+  enumValues: string[];
+}
+
+export function isImport(typ: Type): typ is ImportedType {
+  return 'from' in typ;
+}
+
+export function isAlias(typ: Type): typ is AliasedType {
+  return 'definition' in typ;
+}
+
+export function isEnum(typ: MappableType): typ is EnumType {
+  return typeof typ !== 'string' && 'enumValues' in typ;
+}
+
+export const enum DatabaseTypeType {
+  Base = 'b',
+  Composite = 'c',
+  Domain = 'd',
+  Enum = 'e',
+  Pseudo = 'p',
+  Range = 'r',
+}


### PR DESCRIPTION
This allows pgtyped to generate code from queries involving database
enum types. The postgres enums will be converted to a string-valued const enum
in the generated code.

The `getTypes` reflection query now joins on pg_enum and accumulates
enum information as it collects other type information. I think it may
be possible to accomodate composite types by aggregating over the object
graph given by a suitable join query in a similar way.

@pgtyped/query now returns `MappableTypes` which are either a string
referencing a database type name or a fully-described `Type`. `Type` now
includes `EnumType`. This allows type definitions to be realised at
different stages in the reflection/mapping process and should allow for
custom overrides in config.

fixes #54 