### PR TITLE
Emit type declarations for Typescript too (oops)

### DIFF
--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -47,7 +47,7 @@ type ParsedQuery =
 export async function queryToTypeDeclarations(
   parsedQuery: ParsedQuery,
   connection: any,
-  types: TypeAllocator = new TypeAllocator(DefaultTypeMapping),
+  types: TypeAllocator,
 ): Promise<string> {
   let queryData;
   let queryName;
@@ -187,6 +187,7 @@ async function generateTypedecsFromFile(
           mode: ProcessingMode.TS,
         },
         connection,
+        types,
       );
       const typedQuery = {
         fileName,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -82,13 +82,13 @@ function declareImport([...names]: Set<string>, from: string): string {
 }
 
 function declareAlias(name: string, definition: string): string {
-  return `export type ${name} = ${definition};\n`;
+  return `export type ${name} = ${definition};\n\n`;
 }
 
 function declareEnum(name: string, values: string[]) {
   return `export const enum ${name} {\n${values
     .map((v) => `  ${v} = '${v}',`)
-    .join('\n')}\n}`;
+    .join('\n')}\n}\n`;
 }
 
 /** Wraps a TypeMapping to track which types have been used, to accumulate errors,


### PR DESCRIPTION
Accidentally forgot to pass types to TS generation.

Removed default parameter to avoid this happening and run generator tests against both generations regimes systematically.
