### PR TITLE
Use unions to represent Postgres enum types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,22 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: npm ci
-        run: npm ci
+      - run: npm ci
       - name: Bootstrap packages
         run: npx lerna bootstrap && npm run build
       - name: Run tests
         run: npm test
+
+  test_integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: npm ci
+      - name: Bootstrap packages
+        run: npx lerna bootstrap && npm run build
+      - name: Run integration tests
+        run: npm run test:integration

--- a/package-lock.json
+++ b/package-lock.json
@@ -2653,6 +2653,12 @@
         "readable-stream": "^2.0.6"
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -9726,6 +9732,19 @@
         }
       }
     },
+    "ts-node": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
+      "integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -10421,6 +10440,12 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "watch": "lerna run --parallel watch",
     "lint": "tslint --project tsconfig.json -t verbose",
     "lint!": "npm run lint -- --fix",
-    "test": "npm run lint && jest"
+    "test": "npm run lint && jest",
+    "test:integration": "cd packages/example && docker-compose run test"
   },
   "devDependencies": {
     "@types/jest": "25.2.1",
@@ -18,9 +19,10 @@
     "lerna": "3.20.2",
     "prettier": "2.0.5",
     "ts-jest": "25.5.1",
+    "ts-node": "^8.10.1",
+    "tslint": "6.1.2",
     "tslint-config-prettier": "1.18.0",
     "tslint-plugin-prettier": "2.3.0",
-    "tslint": "6.1.2",
     "typescript": "3.8.3"
   },
   "dependencies": {

--- a/packages/cli/src/generator.test.ts
+++ b/packages/cli/src/generator.test.ts
@@ -61,12 +61,9 @@ describe('query-to-interface translation', () => {
       );
       const expectedTypes = `import { PreparedQuery } from '@pgtyped/query';
 
-export const enum PayloadType {
-  message = 'message',
-  dynamite = 'dynamite',
-}
+export type PayloadType = 'message' | 'dynamite';
 
-export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };\n\n`;
+export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };\n`;
 
       expect(types.declaration()).toEqual(expectedTypes);
       const expected = `/** 'GetNotifications' parameters type */

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -82,7 +82,11 @@ function declareImport([...names]: Set<string>, from: string): string {
 }
 
 function declareAlias(name: string, definition: string): string {
-  return `export type ${name} = ${definition};\n\n`;
+  return `export type ${name} = ${definition};\n`;
+}
+
+function declareStringUnion(name: string, values: string[]) {
+  return declareAlias(name, values.map(v => `'${v}'`).join(' | '))
 }
 
 function declareEnum(name: string, values: string[]) {
@@ -149,9 +153,10 @@ export class TypeAllocator {
       .map(([from, names]) => declareImport(names, from))
       .join('\n');
 
+    // Declare database enums as string unions to maintain assignability of their values between query files
     const enums = Object.values(this.types)
       .filter(isEnum)
-      .map((t) => declareEnum(t.name, t.enumValues))
+      .map((t) => declareStringUnion(t.name, t.enumValues))
       .join('\n');
 
     const aliases = Object.values(this.types)

--- a/packages/example/Dockerfile
+++ b/packages/example/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:13-alpine
 
-WORKDIR /app
+RUN apk add --update --no-cache postgresql-client
 
-ENTRYPOINT cd packages/example && npx pgtyped -w -c config.json
+ADD scripts/wait-for-postgres-then /usr/local/bin/
+
+WORKDIR /app/packages/example
+
+ENTRYPOINT ["scripts/wait-for-postgres-then"]
+

--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -14,7 +14,7 @@ Try starting PgTyped and editing them to see live query type generation.
 `git clone git@github.com:adelsz/pgtyped.git pgyped`
 2. `cd pgtyped/packages/example`
 3. `npm install`
-4. `docker-compose up`
+4. `docker-compose run watch`
 5. Try editing queries in the SQL and TS files and see how PgTyped handles it.
 
 The dockerized setup isn't required and is included for convenience.  

--- a/packages/example/docker-compose.yml
+++ b/packages/example/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./sql/:/docker-entrypoint-initdb.d
 
-  app:
+  build: &build
     build: .
     environment:
       PGHOST: db
@@ -22,6 +22,19 @@ services:
       PGPASSWORD: password
     volumes:
       - ../../:/app
+    working_dir: /app/packages/example
     restart: on-failure
-    links:
+    depends_on:
       - db
+    command: npx pgtyped -c config.json
+
+  watch:
+    <<: *build
+    command: npx pgtyped -w -c config.json
+
+  test:
+    <<: *build
+    depends_on:
+      - build
+    command: npx ts-node src/index.ts
+

--- a/packages/example/package-lock.json
+++ b/packages/example/package-lock.json
@@ -5,11 +5,11 @@
 	"requires": true,
 	"dependencies": {
 		"@pgtyped/cli": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@pgtyped/cli/-/cli-0.6.1.tgz",
-			"integrity": "sha512-3eBnt0fkEEsDIQxrEbFQJoQA1vHZAmg6HcWRD8wfH8wwYpqGd4CZ0qDJfiDZwWfgJPmc1Mkh8coRCEcXSkBfqA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@pgtyped/cli/-/cli-0.7.0.tgz",
+			"integrity": "sha512-YeB4mk8d+UnRNR7mWd2Bfzw3BWzYtcYAEdfPmIbwaYeR2a77lDAoKkH0PjKYMMP78LDNFK/1EgpoRihkOWy8nA==",
 			"requires": {
-				"@pgtyped/query": "^0.6.0",
+				"@pgtyped/query": "^0.7.0",
 				"@types/camel-case": "^1.2.1",
 				"@types/nunjucks": "^3.1.3",
 				"camel-case": "^4.1.1",
@@ -26,20 +26,20 @@
 			}
 		},
 		"@pgtyped/query": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@pgtyped/query/-/query-0.6.0.tgz",
-			"integrity": "sha512-HDwgiMAzTUDU4EvwGryMj+m3k4SU554xkPrhkX7qSdxHktlumhbiCwzgs4JOoPCZyMH0tn0PSUCC7Kna7DWs8g==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@pgtyped/query/-/query-0.7.0.tgz",
+			"integrity": "sha512-Iwb+U+A4SDOb1bPiOsNm8l5UvhJuVFEmI/A2vAI9PCCpUyf6L1FAeWtra3aBLs80jobKzE00156B209UEJQBWg==",
 			"requires": {
-				"@pgtyped/wire": "^0.6.0",
+				"@pgtyped/wire": "^0.7.0",
 				"@types/debug": "^4.1.4",
 				"antlr4ts": "^0.5.0-alpha.3",
 				"debug": "^4.1.1"
 			}
 		},
 		"@pgtyped/wire": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@pgtyped/wire/-/wire-0.6.0.tgz",
-			"integrity": "sha512-pqG8JM9gR0pI3bBeHfWHJwJhT/Yo6b+pIbC5caZ2FPVNav6rESVbd5NiiUE9W5XqIwnr/mZv/yi3VuqcfDgDRA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@pgtyped/wire/-/wire-0.7.0.tgz",
+			"integrity": "sha512-lM5fUZ9awPRn2mjxPo8KSxtcoZ8P37HcTHeT3ihGGBFb83xz2IoNlIJe8g4qzdnMOmJd9eC5BsFybVWWFAh6CQ==",
 			"requires": {
 				"@types/debug": "^4.1.4",
 				"debug": "^4.1.1"
@@ -115,6 +115,12 @@
 				"picomatch": "^2.0.4"
 			}
 		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
+		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -146,6 +152,12 @@
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
 		},
 		"buffer-writer": {
 			"version": "2.0.0",
@@ -216,6 +228,12 @@
 				"ms": "^2.1.1"
 			}
 		},
+		"diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"dev": true
+		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -225,9 +243,9 @@
 			}
 		},
 		"fp-ts": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.5.4.tgz",
-			"integrity": "sha512-cZlLeEneRYypc2dOzB9h8+bd9mQhJVyt2g0Dny2gKR7uWNgA4EmLSJyguLYsTU44nJSSG9EjurUalEc0wQqeKw=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.6.0.tgz",
+			"integrity": "sha512-4EKVa3EOP3NoDwXCLgSCT2t+E2wPCWDXCuj3wEcQ1ovkLfdCMxKxCuElpXptIPBmtA+KbjnUl5Ta/1U3jsCmkg=="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -327,6 +345,12 @@
 			"requires": {
 				"tslib": "^1.10.0"
 			}
+		},
+		"make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -494,6 +518,22 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
 			"integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
 		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
+		},
+		"source-map-support": {
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -523,6 +563,19 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"ts-node": {
+			"version": "8.10.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
+			"integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
+			"dev": true,
+			"requires": {
+				"arg": "^4.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
+			}
+		},
 		"tslib": {
 			"version": "1.11.2",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
@@ -542,6 +595,12 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
 			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true
 		}
 	}
 }

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -26,5 +26,8 @@
     "@types/pg": "7.14.3",
     "pg": "8.1.0",
     "typescript": "3.8.3"
+  },
+  "devDependencies": {
+    "ts-node": "^8.10.1"
   }
 }

--- a/packages/example/scripts/wait-for-postgres-then
+++ b/packages/example/scripts/wait-for-postgres-then
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+RETRIES=${RETRIES:-15}
+
+err_file=$(mktemp)
+
+echo "Checking postgres is up..."
+until pg_isready > /dev/null 2> "$err_file" || [ "$RETRIES" -eq 0 ]; do
+  echo "Waiting for postgres server, retrying $((RETRIES=RETRIES-1)) more times..."
+  sleep 1
+done
+
+[ "$RETRIES" -eq 0 ] && cat "$err_file" && echo "Ensure you have postgresql available on your host machine" && exit 1
+rm "$err_file"
+
+exec "$@"

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -1,19 +1,21 @@
-import { Client, QueryResult } from 'pg';
-import { insertBooks, getBooksByAuthorName } from './books/books.queries';
+import { Client } from 'pg';
+import { getBooksByAuthorName, insertBooks } from './books/books.queries';
 import {
-  notification_type,
   sendNotifications,
   thresholdFrogs,
 } from './notifications/notifications.queries';
+
 // tslint:disable:no-console
 
-export const client = new Client({
-  host: 'localhost',
-  user: 'test',
-  password: 'example',
-  database: 'test',
-  port: 5432,
-});
+const dbConfig = {
+  host: process.env.PGHOST ?? '127.0.0.1',
+  user: process.env.PGUSER ?? 'postgres',
+  password: process.env.PGPASSWORD ?? 'password',
+  database: process.env.PGDATABASE ?? 'postgres',
+  port: (process.env.PGPORT ? Number(process.env.PGPORT) : undefined) ?? 5432,
+};
+
+export const client = new Client(dbConfig);
 
 async function main() {
   await client.connect();
@@ -45,7 +47,7 @@ async function main() {
         {
           user_id: 2,
           payload: { num_frogs: 82 },
-          type: notification_type.reminder,
+          type: 'reminder',
         },
       ],
     },
@@ -59,4 +61,9 @@ async function main() {
   await client.end();
 }
 
-main();
+main()
+  .then(() => console.log('Successfully ran example code!'))
+  .catch((err) => {
+    console.error(`Error running example code: ${err.stack}`);
+    process.exit(1);
+  });

--- a/packages/example/src/notifications/notifications.queries.ts
+++ b/packages/example/src/notifications/notifications.queries.ts
@@ -1,11 +1,8 @@
 /** Types generated for queries found in "./src/notifications/notifications.sql" */
 import { PreparedQuery } from '@pgtyped/query';
 
-export const enum notification_type {
-  notification = 'notification',
-  reminder = 'reminder',
-  deadline = 'deadline',
-}
+export type notification_type = 'notification' | 'reminder' | 'deadline';
+
 export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
 
 /** 'SendNotifications' parameters type */


### PR DESCRIPTION
This provides assignability between enum-mapped types from different
query files where Typescript enums would be incompatible.

Also harness up pacakges/example as a form of integration/smoke test in
CI.

fixes #65 