### PR TITLE
extend types with bpchar

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -46,6 +46,7 @@ export const DefaultTypeMapping = Object.freeze({
   text: String,
   varchar: String,
   char: String,
+  bpchar: String,
   citext: String,
 
   // Bool types


### PR DESCRIPTION
bpchar (blank padded char) is the internal name of char and without this the cli fails, because the type is not known

https://stackoverflow.com/questions/51421269/why-char-datatype-is-converted-to-bpchar-automatically