### PR TITLE
remove @types/camel-case

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@pgtyped/query": "^0.8.1",
-    "@types/camel-case": "^1.2.1",
     "@types/nunjucks": "^3.1.3",
     "camel-case": "^4.1.1",
     "chalk": "^4.0.0",


### PR DESCRIPTION
it is deprecated

follow up on https://github.com/adelsz/pgtyped/issues/135

@adelsz how can I use the dependencies bot to update `package.lock` ?