### PR TITLE
Exporting IDatabaseConnection

### DIFF
--- a/packages/query/src/tag.ts
+++ b/packages/query/src/tag.ts
@@ -4,7 +4,7 @@ import { Query as QueryAST } from './loader/sql';
 import { parseTSQuery, TSQueryAST } from './loader/typescript';
 import { parseTypeScriptFile } from './index';
 
-interface IDatabaseConnection {
+export interface IDatabaseConnection {
   query: (query: string, bindings: any[]) => Promise<{ rows: any[] }>;
 }
 


### PR DESCRIPTION
I found myself writing a piece of code that looked like this:

```Typescript
async function doSomeDbRelatedTask(db?: IDatabaseConnection): Promise<void> {
	db = db || postgres
	await someQuery.run({ someParams }, db)
}
```

Which can work inside a given transaction or on it's own. `postgres` is a global db connection that has type [`Pool`](https://node-postgres.com/api/pool), but when this is used inside a transaction, I provide an argument of type [`PoolClient`](https://node-postgres.com/api/client).

Naturally, I want to use some type to describe them both in my code, and `IDatabaseConnection` is exactly what I need, so why not make it public so I can use it in my code?