### PR TITLE
make params that are arrays readonly in ts

### DIFF
--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -116,7 +116,7 @@ export async function queryToTypeDeclarations(
 
       paramFieldTypes.push({
         fieldName: param.name,
-        fieldType: isArray ? `Array<${tsTypeName}>` : tsTypeName,
+        fieldType: isArray ? `readonly (${tsTypeName})[]` : tsTypeName,
       });
     } else {
       const isArray = param.type === ParamTransform.PickSpread;
@@ -128,7 +128,7 @@ export async function queryToTypeDeclarations(
         .join(',\n');
       fieldType = `{\n${fieldType}\n  }`;
       if (isArray) {
-        fieldType = `Array<${fieldType}>`;
+        fieldType = `readonly (${fieldType})[]`;
       }
       paramFieldTypes.push({
         fieldName: param.name,


### PR DESCRIPTION
This updates the generated array types from `Array<T>` to `readonly T[]`

Since the arrays passed in to the generated functions are not being mutated, it would be nice if they were typed as `readonly` so that consumers with a readonly array can use that array as an arg w/o cloning it.