### PR TITLE
Add support for SSL

### DIFF
--- a/docs-new/docs/cli.md
+++ b/docs-new/docs/cli.md
@@ -11,9 +11,10 @@ while build mode can be used for generating types when running CI.
 ### Flags
 
 The CLI supports three flags:
-* `-c config_file_path.json` to pass the config file path.
-* `-w` to start in watch mode.
-* `-f file_path.ts` if you only want to process one file (which can be useful when working on a big project). Incompatible with watch mode. Uses transforms defined in the config file to determine the mode and emit template, so a file path that doesn't fit the include glob patterns will not be processed.
+
+- `-c config_file_path.json` to pass the config file path.
+- `-w` to start in watch mode.
+- `-f file_path.ts` if you only want to process one file (which can be useful when working on a big project). Incompatible with watch mode. Uses transforms defined in the config file to determine the mode and emit template, so a file path that doesn't fit the include glob patterns will not be processed.
 
 ```shell script title="Example:"
 npx pgtyped -w -c config.json
@@ -56,7 +57,9 @@ These variables will override values provided in `config.json`.
     "dbName": "testdb", // DB name
     "user": "user", // DB username
     "password": "password", // DB password (optional)
-    "host": "127.0.0.1" // DB host (optional)
+    "host": "127.0.0.1", // DB host (optional)
+    "port": 5432, // DB port (optional)
+    "ssl": false // Whether or not to connect to DB with SSL (optional)
   }
 }
 ```
@@ -76,4 +79,58 @@ For example, when parsing source/query file `/home/user/dir/file.sql`, these par
 "  /    home/user/dir / file  .sql "
 └──────┴──────────────┴──────┴─────┘
 (All spaces in the "" line should be ignored. They are purely for formatting.)
+```
+
+### Configuring SSL options
+
+Options can also be provided to customize the certificate used or to ignore SSL errors. More information about options can be found [here](https://nodejs.org/api/tls.html#tls_new_tls_tlssocket_socket_options).
+
+Sample configuration files have been provided below.
+
+```js title="custom_ca.json"
+{
+  "transforms": [
+    {
+      "mode": "sql",
+      "include": "**/*.sql",
+      "emitTemplate": "{{dir}}/{{name}}.queries.ts"
+    }
+  ],
+  "srcDir": "./src/",
+  "failOnError": false,
+  "camelCaseColumnNames": false,
+  "db": {
+    "dbName": "testdb",
+    "user": "user",
+    "host": "someremote.host.com",
+    "ssl": {
+      "host": "someremote.host.com",
+      "port": 5432,
+      "ca": ["insert CA here"]
+    }
+  }
+}
+```
+
+```js title="ignore_ssl.json"
+{
+  "transforms": [
+    {
+      "mode": "sql",
+      "include": "**/*.sql",
+      "emitTemplate": "{{dir}}/{{name}}.queries.ts"
+    }
+  ],
+  "srcDir": "./src/",
+  "failOnError": false,
+  "camelCaseColumnNames": false,
+  "db": {
+    "dbName": "testdb",
+    "user": "user",
+    "host": "someremote.host.com",
+    "ssl": {
+      "rejectUnauthorized": false
+    }
+  }
+}
 ```

--- a/docs-new/docs/cli.md
+++ b/docs-new/docs/cli.md
@@ -83,6 +83,8 @@ For example, when parsing source/query file `/home/user/dir/file.sql`, these par
 
 ### Configuring SSL options
 
+By default, if enabled it will attempt to verify the SSL connection with the local certificates on the machine.
+
 Options can also be provided to customize the certificate used or to ignore SSL errors. More information about options can be found [here](https://nodejs.org/api/tls.html#tls_new_tls_tlssocket_socket_options).
 
 Sample configuration files have been provided below.

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -4,6 +4,7 @@ import * as Either from 'fp-ts/lib/Either';
 import { join, isAbsolute } from 'path';
 import * as t from 'io-ts';
 import { reporter } from 'io-ts-reporters';
+import tls from 'tls';
 
 const transformCodecProps = {
   include: t.string,
@@ -38,6 +39,7 @@ const configParser = t.type({
       port: t.union([t.number, t.undefined]),
       user: t.union([t.string, t.undefined]),
       dbName: t.union([t.string, t.undefined]),
+      ssl: t.union([t.UnknownRecord, t.boolean, t.undefined]),
     }),
     t.undefined,
   ]),
@@ -52,6 +54,7 @@ export interface ParsedConfig {
     password: string | undefined;
     dbName: string;
     port: number;
+    ssl?: tls.ConnectionOptions | boolean;
   };
   failOnError: boolean;
   camelCaseColumnNames: boolean;

--- a/packages/query/src/actions.ts
+++ b/packages/query/src/actions.ts
@@ -1,5 +1,6 @@
 import { AsyncQueue, messages, PreparedObjectType } from '@pgtyped/wire';
 import crypto from 'crypto';
+import tls from 'tls';
 import debugBase from 'debug';
 
 import { IInterpolatedQuery, QueryParam } from './preprocessor';
@@ -28,6 +29,7 @@ export async function startup(
     port: number;
     user: string;
     dbName: string;
+    ssl?: tls.ConnectionOptions | boolean;
   },
   queue: AsyncQueue,
 ) {

--- a/packages/wire/src/messages.ts
+++ b/packages/wire/src/messages.ts
@@ -52,6 +52,16 @@ export enum PreparedObjectType {
 }
 
 export const messages = {
+  /** SSLRequest message requests SSL from a remote host  */
+  sslRequest: {
+    name: 'SSLRequest',
+    type: 'CLIENT',
+    indicator: null,
+    pattern: () => [
+      // The SSL request code.
+      int32(80877103),
+    ],
+  } as IClientMessage<{}>,
   /** ReadyForQuery message informs the frontend that it can safely send a new command. */
   readyForQuery: {
     name: 'ReadyForQuery',

--- a/packages/wire/src/queue.ts
+++ b/packages/wire/src/queue.ts
@@ -9,7 +9,7 @@ import {
   ParseResult,
 } from './protocol';
 
-import { IClientMessage, TMessage, IServerMessage } from './messages';
+import { IClientMessage, TMessage, IServerMessage, messages } from './messages';
 
 import debugBase from 'debug';
 const debug = debugBase('pg-wire:socket');
@@ -50,11 +50,7 @@ export class AsyncQueue {
         debug('socket connected');
 
         if (sslEnabled) {
-          const requestSSLMessage = Buffer.allocUnsafe(8);
-          requestSSLMessage.writeInt32BE(8, 0);
-          requestSSLMessage.writeInt32BE(80877103, 4);
-
-          this.socket.write(requestSSLMessage);
+          this.send(messages.sslRequest, {});
         } else {
           attachDataListener();
           resolve();
@@ -88,6 +84,7 @@ export class AsyncQueue {
           if (net.isIP(connectOptions.host) === 0) {
             options.servername = connectOptions.host;
           }
+
           try {
             this.socket = tls.connect(options);
           } catch (err) {

--- a/packages/wire/src/queue.ts
+++ b/packages/wire/src/queue.ts
@@ -9,12 +9,7 @@ import {
   ParseResult,
 } from './protocol';
 
-import {
-  IClientMessage,
-  TMessage,
-  IServerMessage,
-  messages as protocolMessages,
-} from './messages';
+import { IClientMessage, TMessage, IServerMessage, messages } from './messages';
 
 import debugBase from 'debug';
 const debug = debugBase('pg-wire:socket');
@@ -55,7 +50,7 @@ export class AsyncQueue {
         debug('socket connected');
 
         if (sslEnabled) {
-          this.send(protocolMessages.sslRequest, {});
+          this.send(messages.sslRequest, {});
         } else {
           attachDataListener();
           resolve();
@@ -146,19 +141,19 @@ export class AsyncQueue {
   }
   /**
    * Waits for the next message to arrive and parses it, resolving with the parsed value.
-   * @param messages The message type to parse or an array of messages to match any of them
+   * @param serverMessages The message type to parse or an array of messages to match any of them
    * @returns The parsed params
    */
   public async reply<Messages extends Array<IServerMessage<any>>>(
-    ...messages: Messages
+    ...serverMessages: Messages
   ): Promise<Boxified<Messages>[number]> {
     let parser: (buf: Buffer, offset: number) => ParseResult<object>;
-    if (messages instanceof Array) {
+    if (serverMessages instanceof Array) {
       parser = (buf: Buffer, offset: number) =>
-        parseOneOf(messages, buf, offset);
+        parseOneOf(serverMessages, buf, offset);
     } else {
       parser = (buf: Buffer, offset: number) =>
-        parseMessage(messages, buf, offset);
+        parseMessage(serverMessages, buf, offset);
     }
     return new Promise((resolve, reject) => {
       this.replyPending = {

--- a/packages/wire/src/queue.ts
+++ b/packages/wire/src/queue.ts
@@ -77,7 +77,7 @@ export class AsyncQueue {
               );
           }
 
-          const options = {
+          const options: tls.ConnectionOptions = {
             socket: this.socket,
           };
 
@@ -85,6 +85,9 @@ export class AsyncQueue {
             Object.assign(options, ssl);
           }
 
+          if (net.isIP(connectOptions.host) === 0) {
+            options.servername = connectOptions.host;
+          }
           try {
             this.socket = tls.connect(options);
           } catch (err) {

--- a/packages/wire/src/queue.ts
+++ b/packages/wire/src/queue.ts
@@ -49,15 +49,15 @@ export class AsyncQueue {
       this.socket.on('connect', () => {
         debug('socket connected');
 
-        if (!sslEnabled) {
-          attachDataListener();
-          resolve();
-        } else {
+        if (sslEnabled) {
           const requestSSLMessage = Buffer.allocUnsafe(8);
           requestSSLMessage.writeInt32BE(8, 0);
           requestSSLMessage.writeInt32BE(80877103, 4);
 
           this.socket.write(requestSSLMessage);
+        } else {
+          attachDataListener();
+          resolve();
         }
       });
 

--- a/packages/wire/src/queue.ts
+++ b/packages/wire/src/queue.ts
@@ -9,7 +9,12 @@ import {
   ParseResult,
 } from './protocol';
 
-import { IClientMessage, TMessage, IServerMessage, messages } from './messages';
+import {
+  IClientMessage,
+  TMessage,
+  IServerMessage,
+  messages as protocolMessages,
+} from './messages';
 
 import debugBase from 'debug';
 const debug = debugBase('pg-wire:socket');
@@ -50,7 +55,7 @@ export class AsyncQueue {
         debug('socket connected');
 
         if (sslEnabled) {
-          this.send(messages.sslRequest, {});
+          this.send(protocolMessages.sslRequest, {});
         } else {
           attachDataListener();
           resolve();

--- a/packages/wire/src/queue.ts
+++ b/packages/wire/src/queue.ts
@@ -34,7 +34,7 @@ export class AsyncQueue {
     host: string;
     ssl?: tls.ConnectionOptions | boolean;
   }): Promise<void> {
-    const { ssl, ...options } = passedOptions;
+    const { ssl, ...connectOptions } = passedOptions;
     const sslEnabled = ssl === true || ssl != null;
 
     const attachDataListener = () => {
@@ -101,7 +101,7 @@ export class AsyncQueue {
         });
       }
 
-      this.socket.connect(options);
+      this.socket.connect(connectOptions);
     });
   }
   public async send<Params extends object>(


### PR DESCRIPTION
This adds support for SSL connections.

You can provide SSL options in the db config:
Providing certificate to verify SSL/TLS
```
ssl: {
  host: "insert IP of remote database",
  port: 5432,
  ca: ["insert ca cert here"],
}
```

Ignoring SSL/TLS errors; allows for MITM attacks to occur
or 

```
"ssl": {
  "rejectUnauthorized": false
}
```

or 

Checks local certificate
```
"ssl": true
```