### PR TITLE
Allow db config to be provided as a URL

### DIFF
--- a/docs-new/docs/cli.md
+++ b/docs-new/docs/cli.md
@@ -4,7 +4,7 @@ title: CLI config
 sidebar_label: CLI config
 ---
 
-`pgtyped` CLI can be launched in build or watch mode.  
+`pgtyped` CLI can be launched in build or watch mode.
 Watch mode is most useful for a local development workflow,
 while build mode can be used for generating types when running CI.
 
@@ -53,6 +53,7 @@ These variables will override values provided in `config.json`.
   "srcDir": "./src/", // Directory to scan or watch for query files
   "failOnError": false, // Whether to fail on a file processing error and abort generation (can be omitted - default is false)
   "camelCaseColumnNames": false, // convert to camelCase column names of result interface
+  "dbUrl": "postgres://user:password@host/database", // DB URL (optional - will be merged with db if provided)
   "db": {
     "dbName": "testdb", // DB name
     "user": "user", // DB username
@@ -66,9 +67,9 @@ These variables will override values provided in `config.json`.
 
 ### Customizing generated file paths
 
-By default, PgTyped saves generated files in the same folder as the source files it parses.  
-This behavior can be customized using the `emitTemplate` config parameter.  
-In that template, four parameters are available for interpolation: `root`, `dir`, `base`, `name` and `ext`.  
+By default, PgTyped saves generated files in the same folder as the source files it parses.
+This behavior can be customized using the `emitTemplate` config parameter.
+In that template, four parameters are available for interpolation: `root`, `dir`, `base`, `name` and `ext`.
 For example, when parsing source/query file `/home/user/dir/file.sql`, these parameters are assigned the following values:
 
 ```

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -292,6 +292,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
+    "mongodb-uri": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz",
+      "integrity": "sha1-D3ca0W9IOuZfQoeWlCjp+8SqYYE="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -371,6 +376,14 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "ts-parse-database-url": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ts-parse-database-url/-/ts-parse-database-url-1.0.3.tgz",
+      "integrity": "sha512-7AIP9EZyKsgaeGpu+Yhu6xDQtwbKDfkw5zBUsuYXju79tFRj6u8w2W+5Ag5wtCS6LM1jOB4iIqDNyFYX758wVQ==",
+      "requires": {
+        "mongodb-uri": "^0.9.7"
       }
     },
     "tslib": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,8 @@
     "io-ts-reporters": "^1.0.0",
     "minimist": "^1.2.5",
     "nunjucks": "3.2.2",
-    "pascal-case": "^3.1.1"
+    "pascal-case": "^3.1.1",
+    "ts-parse-database-url": "^1.0.3"
   },
   "devDependencies": {
     "@types/debug": "4.1.5",


### PR DESCRIPTION
Database URLs are a common way to connect to databases, and supporting them is helpful to end users.