### PR TITLE
Allow to pass database url from env as well

### DIFF
--- a/docs-new/docs/cli.md
+++ b/docs-new/docs/cli.md
@@ -54,6 +54,7 @@ These variables will override values provided in `config.json`.
   "failOnError": false, // Whether to fail on a file processing error and abort generation (can be omitted - default is false)
   "camelCaseColumnNames": false, // convert to camelCase column names of result interface
   "dbUrl": "postgres://user:password@host/database", // DB URL (optional - will be merged with db if provided)
+  "dbUrlEnvName": "DATABASE_URL", // DB URL env name (optional - will be read from .env) 
   "db": {
     "dbName": "testdb", // DB name
     "user": "user", // DB username


### PR DESCRIPTION
This basically should allow passing a custom env variable name as a database URL. Some will prefer `DB_URL`; others will prefer `DATABASE_URL`. In my case, I'm using other services that require the database URL, and I prefer not to duplicate the variables.

BEFORE YOU APPROVE / MERGE - I haven't tested this behavior since I couldn't find existing tests of the configuration. If there is, please let me know so I can test it as well.