### PR TITLE
Fix `antlr4ts` crash when using Yarn V2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5222,7 +5222,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "handlebars": {
       "version": "4.7.7",
@@ -5918,6 +5919,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -7505,6 +7507,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -7519,6 +7522,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -7528,6 +7532,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -7536,7 +7541,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9000,7 +9006,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -10127,7 +10134,8 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "v8-to-istanbul": {
       "version": "7.0.0",

--- a/packages/query/package-lock.json
+++ b/packages/query/package-lock.json
@@ -1,9 +1,165 @@
 {
   "name": "@pgtyped/query",
   "version": "0.10.2",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@pgtyped/query",
+      "version": "0.10.2",
+      "license": "MIT",
+      "dependencies": {
+        "@pgtyped/wire": "^0.10.1",
+        "@types/chalk": "^2.2.0",
+        "@types/debug": "^4.1.4",
+        "antlr4ts": "0.5.0-alpha.4",
+        "chalk": "^4.1.0",
+        "debug": "^4.1.1"
+      },
+      "devDependencies": {
+        "antlr4ts-cli": "0.5.0-alpha.4"
+      },
+      "peerDependencies": {
+        "typescript": "3.1 - 4"
+      }
+    },
+    "node_modules/@pgtyped/wire": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@pgtyped/wire/-/wire-0.10.1.tgz",
+      "integrity": "sha512-eJ0G5r5RJmeGuDeanx9raYHRgfEDk+tzKKGzNxgrNjKNSk5mKAtqXye6lujL9PxpZJXGMfX82bBDHCCB8wyb2A==",
+      "dependencies": {
+        "@types/debug": "^4.1.4",
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@types/chalk": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
+      "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
+      "dependencies": {
+        "chalk": "*"
+      }
+    },
+    "node_modules/@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "dependencies": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/antlr4ts": {
+      "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
+      "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ=="
+    },
+    "node_modules/antlr4ts-cli": {
+      "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts-cli/-/antlr4ts-cli-0.5.0-alpha.4.tgz",
+      "integrity": "sha512-lVPVBTA2CVHRYILSKilL6Jd4hAumhSZZWA7UbQNQrmaSSj7dPmmYaN4bOmZG79cOy0lS00i4LY68JZZjZMWVrw==",
+      "dev": true,
+      "bin": {
+        "antlr4ts": "antlr4ts"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
+    "@pgtyped/wire": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@pgtyped/wire/-/wire-0.10.1.tgz",
+      "integrity": "sha512-eJ0G5r5RJmeGuDeanx9raYHRgfEDk+tzKKGzNxgrNjKNSk5mKAtqXye6lujL9PxpZJXGMfX82bBDHCCB8wyb2A==",
+      "requires": {
+        "@types/debug": "^4.1.4",
+        "debug": "^4.1.1"
+      }
+    },
     "@types/chalk": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
@@ -32,14 +188,14 @@
       }
     },
     "antlr4ts": {
-      "version": "0.5.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
-      "integrity": "sha512-La89tKkGcHFIVuruv4Bm1esc3zLmES2NOTEwwNS1pudz+zx/0FNqQeUu9p48i9/QHKPVqjN87LB+q3buTg7oDQ=="
+      "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
+      "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ=="
     },
     "antlr4ts-cli": {
-      "version": "0.5.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/antlr4ts-cli/-/antlr4ts-cli-0.5.0-alpha.3.tgz",
-      "integrity": "sha512-i6oyxfaXU6qnw4HgyeSIsOLlsvT7zU3vmenoJKFNVFP1QNodtJMZYpnyxc8TmOFpJs7fEoWanLavSSDEmcCZBQ==",
+      "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts-cli/-/antlr4ts-cli-0.5.0-alpha.4.tgz",
+      "integrity": "sha512-lVPVBTA2CVHRYILSKilL6Jd4hAumhSZZWA7UbQNQrmaSSj7dPmmYaN4bOmZG79cOy0lS00i4LY68JZZjZMWVrw==",
       "dev": true
     },
     "chalk": {
@@ -89,6 +245,12 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "peer": true
     }
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -27,12 +27,12 @@
     "@pgtyped/wire": "^0.10.1",
     "@types/chalk": "^2.2.0",
     "@types/debug": "^4.1.4",
-    "antlr4ts": "^0.5.0-alpha.3",
+    "antlr4ts": "0.5.0-alpha.4",
     "chalk": "^4.1.0",
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "antlr4ts-cli": "0.5.0-alpha.3"
+    "antlr4ts-cli": "0.5.0-alpha.4"
   },
   "peerDependencies": {
     "typescript": "3.1 - 4"

--- a/packages/query/src/loader/sql/parser/SQLLexer.ts
+++ b/packages/query/src/loader/sql/parser/SQLLexer.ts
@@ -1,4 +1,4 @@
-// Generated from src/loader/sql/grammar/SQLLexer.g4 by ANTLR 4.7.3-SNAPSHOT
+// Generated from src/loader/sql/grammar/SQLLexer.g4 by ANTLR 4.9.0-SNAPSHOT
 
 
 import { ATN } from "antlr4ts/atn/ATN";

--- a/packages/query/src/loader/sql/parser/SQLParser.ts
+++ b/packages/query/src/loader/sql/parser/SQLParser.ts
@@ -1,4 +1,4 @@
-// Generated from src/loader/sql/grammar/SQLParser.g4 by ANTLR 4.7.3-SNAPSHOT
+// Generated from src/loader/sql/grammar/SQLParser.g4 by ANTLR 4.9.0-SNAPSHOT
 
 
 import { ATN } from "antlr4ts/atn/ATN";
@@ -100,6 +100,10 @@ export class SQLParser extends Parser {
 
 	// @Override
 	public get serializedATN(): string { return SQLParser._serializedATN; }
+
+	protected createFailedPredicateException(predicate?: string, message?: string): FailedPredicateException {
+		return new FailedPredicateException(this, predicate, message);
+	}
 
 	constructor(input: TokenStream) {
 		super(input);

--- a/packages/query/src/loader/sql/parser/SQLParserListener.ts
+++ b/packages/query/src/loader/sql/parser/SQLParserListener.ts
@@ -1,4 +1,4 @@
-// Generated from src/loader/sql/grammar/SQLParser.g4 by ANTLR 4.7.3-SNAPSHOT
+// Generated from src/loader/sql/grammar/SQLParser.g4 by ANTLR 4.9.0-SNAPSHOT
 
 
 import { ParseTreeListener } from "antlr4ts/tree/ParseTreeListener";

--- a/packages/query/src/loader/sql/parser/SQLParserVisitor.ts
+++ b/packages/query/src/loader/sql/parser/SQLParserVisitor.ts
@@ -1,4 +1,4 @@
-// Generated from src/loader/sql/grammar/SQLParser.g4 by ANTLR 4.7.3-SNAPSHOT
+// Generated from src/loader/sql/grammar/SQLParser.g4 by ANTLR 4.9.0-SNAPSHOT
 
 
 import { ParseTreeVisitor } from "antlr4ts/tree/ParseTreeVisitor";

--- a/packages/query/src/loader/typescript/parser/QueryLexer.ts
+++ b/packages/query/src/loader/typescript/parser/QueryLexer.ts
@@ -1,4 +1,4 @@
-// Generated from src/loader/typescript/grammar/QueryLexer.g4 by ANTLR 4.7.3-SNAPSHOT
+// Generated from src/loader/typescript/grammar/QueryLexer.g4 by ANTLR 4.9.0-SNAPSHOT
 
 
 import { ATN } from "antlr4ts/atn/ATN";

--- a/packages/query/src/loader/typescript/parser/QueryParser.ts
+++ b/packages/query/src/loader/typescript/parser/QueryParser.ts
@@ -1,4 +1,4 @@
-// Generated from src/loader/typescript/grammar/QueryParser.g4 by ANTLR 4.7.3-SNAPSHOT
+// Generated from src/loader/typescript/grammar/QueryParser.g4 by ANTLR 4.9.0-SNAPSHOT
 
 
 import { ATN } from "antlr4ts/atn/ATN";
@@ -80,6 +80,10 @@ export class QueryParser extends Parser {
 
 	// @Override
 	public get serializedATN(): string { return QueryParser._serializedATN; }
+
+	protected createFailedPredicateException(predicate?: string, message?: string): FailedPredicateException {
+		return new FailedPredicateException(this, predicate, message);
+	}
 
 	constructor(input: TokenStream) {
 		super(input);

--- a/packages/query/src/loader/typescript/parser/QueryParserListener.ts
+++ b/packages/query/src/loader/typescript/parser/QueryParserListener.ts
@@ -1,4 +1,4 @@
-// Generated from src/loader/typescript/grammar/QueryParser.g4 by ANTLR 4.7.3-SNAPSHOT
+// Generated from src/loader/typescript/grammar/QueryParser.g4 by ANTLR 4.9.0-SNAPSHOT
 
 
 import { ParseTreeListener } from "antlr4ts/tree/ParseTreeListener";

--- a/packages/query/src/loader/typescript/parser/QueryParserVisitor.ts
+++ b/packages/query/src/loader/typescript/parser/QueryParserVisitor.ts
@@ -1,4 +1,4 @@
-// Generated from src/loader/typescript/grammar/QueryParser.g4 by ANTLR 4.7.3-SNAPSHOT
+// Generated from src/loader/typescript/grammar/QueryParser.g4 by ANTLR 4.9.0-SNAPSHOT
 
 
 import { ParseTreeVisitor } from "antlr4ts/tree/ParseTreeVisitor";


### PR DESCRIPTION
When using this package in a Yarn V2 project the following error occurs because of circular references in the `antlr4ts` dependency:
```
class XPathLexer extends __2.Lexer {
                             ^

TypeError: Class extends value undefined is not a constructor or null
at Object.<anonymous> (app/node_modules/antlr4ts/dist/tree/xpath/XPathLexer.js:9:30)
  at Module._compile (node:internal/modules/cjs/loader:1092:14)
  at Object.Module._extensions..js (node:internal/modules/cjs/loader:1121:10)
  at Module.load (node:internal/modules/cjs/loader:972:32)
  at Function.external_module_.Module._load (.pnp.js:52489:14)
  at Module.require (node:internal/modules/cjs/loader:996:19)
  at require (node:internal/modules/cjs/helpers:92:18)
  at Object.<anonymous> (app/node_modules/antlr4ts/dist/tree/xpath/XPath.js:13:22)
    at Module._compile (node:internal/modules/cjs/loader:1092:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1121:10)
```

Luckily issue is already fixed in the `antlr4ts` library: https://github.com/tunnelvisionlabs/antlr4ts/issues/461 in their `0.5.0-alpha.4` version.

Unfortunately we have to fix it exactly this version (so no `^`) in the `package.json` as their versioning is wrong (see https://semver.org/#spec-item-11 11.3). Otherwise Yarn will resolve it to `0.5.0-dev` which is an older version.