### PR TITLE
Create directories when writing files

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -15,6 +15,15 @@
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.11.tgz",
+      "integrity": "sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -75,6 +84,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -180,6 +194,17 @@
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.5.3.tgz",
       "integrity": "sha512-lQd+hahLd8cygNoXbEHDjH/cbF6XVWlEPb8h5GXXlozjCSDxWgclvkpOoTRfBA0P+r69l9VvW1nEsSGIJRQpWw=="
     },
+    "fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -211,6 +236,11 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "has-flag": {
       "version": "4.0.0",
@@ -270,6 +300,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
     },
     "lower-case": {
       "version": "2.0.1",
@@ -389,6 +428,11 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,7 @@
     "chokidar": "^3.3.1",
     "debug": "^4.1.1",
     "fp-ts": "^2.5.3",
+    "fs-extra": "^9.1.0",
     "glob": "^7.1.6",
     "io-ts": "^2.1.2",
     "io-ts-reporters": "^1.0.0",
@@ -41,6 +42,7 @@
   },
   "devDependencies": {
     "@types/debug": "4.1.5",
+    "@types/fs-extra": "^9.0.11",
     "@types/glob": "7.1.3",
     "@types/minimist": "1.2.1"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,17 +2,14 @@
 
 import { AsyncQueue, startup } from '@pgtyped/query';
 import chokidar from 'chokidar';
-import fs from 'fs';
+import fs from 'fs-extra';
 import glob from 'glob';
 import minimist from 'minimist';
 import nun from 'nunjucks';
 import path from 'path';
-import { promisify } from 'util';
 import { parseConfig, ParsedConfig, TransformConfig } from './config';
 import { generateDeclarationFile } from './generator';
 import { debug } from './util';
-
-const writeFile = promisify(fs.writeFile);
 
 const args = minimist(process.argv.slice(2));
 
@@ -93,7 +90,7 @@ class FileProcessor {
         this.config,
       );
       if (typeDecs.length > 0) {
-        await writeFile(decsFileName, declarationFileContents);
+        await fs.outputFile(decsFileName, declarationFileContents);
         console.log(
           `Saved ${typeDecs.length} query types to ${path.relative(
             process.cwd(),


### PR DESCRIPTION
When emitting files in a directory other than the source directory the write can fail if the intermediary directories does not exist. This uses [outputFile](https://github.com/jprichardson/node-fs-extra/blob/master/docs/outputFile.md) from fs-extra which creates directories if needed.