### PR TITLE
feat: only write files if the content differs

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -90,13 +90,18 @@ class FileProcessor {
         this.config,
       );
       if (typeDecs.length > 0) {
-        await fs.outputFile(decsFileName, declarationFileContents);
-        console.log(
-          `Saved ${typeDecs.length} query types to ${path.relative(
-            process.cwd(),
-            decsFileName,
-          )}`,
-        );
+        const oldDeclarationFileContents = (await fs.pathExists(decsFileName))
+          ? await fs.readFile(decsFileName, { encoding: 'utf-8' })
+          : null;
+        if (oldDeclarationFileContents !== declarationFileContents) {
+          await fs.outputFile(decsFileName, declarationFileContents);
+          console.log(
+            `Saved ${typeDecs.length} query types to ${path.relative(
+              process.cwd(),
+              decsFileName,
+            )}`,
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
This is useful in conjunction with tools like nodemon that monitor for
file changes. By only writing files if the content has actually changed,
unnecessary side effects (like nodemon restarting) can be avoided.

Fixes #257