### PR TITLE
Run CI on all pushes / PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Github Actions doesn't have any limits for open source projects so we
can make it run as often as possible.

It seems now the CI doesn't run on some PRs so perhaps relaxing the
triggers will fix it: https://github.com/adelsz/pgtyped/pull/288

This reverts the change from 3e304e5cea6745418b3a9c42b4f952d8562f7be7.