### PR TITLE
Remove docker-compose containers and network after tests

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -14,7 +14,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "docker-compose run test",
+    "test": "docker-compose run test; docker-compose down",
     "typegen": "pgtyped -c config.json",
     "build": "tsc --declaration",
     "watch": "tsc --declaration --watch --preserveWatchOutput",


### PR DESCRIPTION
Otherwise they will keep running (I discovered that when I tried starting my own PostgreSQL and the port was blocked).