### PR TITLE
add Postgis Point type as number[]

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -82,6 +82,9 @@ export const DefaultTypeMapping = Object.freeze({
 
   // Bytes
   bytea: Bytes,
+
+  // Postgis types
+  point: getArray(Number),
 });
 
 export type BuiltinTypes = keyof typeof DefaultTypeMapping;


### PR DESCRIPTION
This PR simply adds an extra type to `cli/src/types.ts`, for the Postgis column type `point`. The type is a `number[]`. Technically it could be typed more strictly as `[number, number]`, but I believe that would involve more significant changes to pgTyped, and this is perfectly acceptable for our purposes. 

I have tested this by building the code and linking the `@pgtyped/cli` package to my application. It successfully removes the `column type not supported by mapping` errors that I was seeing before. 

Apologies if I have missed anything. Let me know if there are any further changes to make! Thank you.

This is a rudimentary solution to the issue discussed in #232, although only for the `point` type. I would be happy to add more Postgis types if there is demand for it.