### PR TITLE
Add `name` to type mapping

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -52,6 +52,7 @@ export const DefaultTypeMapping = Object.freeze({
   char: String,
   bpchar: String,
   citext: String,
+  name: String,
 
   // Bool types
   bit: Boolean, // TODO: better bit array support


### PR DESCRIPTION
fixes #315

I've just taken a pot shot here, looking for some initial feedback. Is it this simple?