### PR TITLE
Use unknown instead of never

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -152,7 +152,7 @@ export class TypeAllocator {
               `Postgres type '${typeNameOrType}' is not supported by mapping`,
             ),
           );
-          return 'never';
+          return 'unknown';
         }
         typ = this.mapping[typeNameOrType];
       }


### PR DESCRIPTION
I would like to use TSTZRange types in my pgtyped queries. Pgtyped should allow users to use unsupported types through calling them unknown.