### PR TITLE
sorted generator fields

### DIFF
--- a/packages/cli/src/generator.test.ts
+++ b/packages/cli/src/generator.test.ts
@@ -228,16 +228,16 @@ export interface IInsertNotificationsQuery {
       );
       const expected = `/** 'DeleteUsers' parameters type */
 export interface IDeleteUsersParams {
-  userName: string | null | void;
   userId: string | null | void;
+  userName: string | null | void;
   userNote: string | null | void;
 }
 
 /** 'DeleteUsers' return type */
 export interface IDeleteUsersResult {
+  bote: string | null;
   id: string;
   name: string;
-  bote: string | null;
 }
 
 /** 'DeleteUsers' query type */
@@ -475,8 +475,8 @@ export interface IGetNotificationsQuery {
 
 test('interface generation', () => {
   const expected = `export interface User {
-  name: string;
   age: number;
+  name: string;
 }
 
 `;

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -27,7 +27,10 @@ ${contents}
 }\n\n`;
 
 export const generateInterface = (interfaceName: string, fields: IField[]) => {
-  const contents = fields
+  const sortedFields = fields.slice().sort((a, b) =>
+    a.fieldName.localeCompare(b.fieldName),
+  );
+  const contents = sortedFields
     .map(({ fieldName, fieldType }) => `  ${fieldName}: ${fieldType};`)
     .join('\n');
   return interfaceGen(interfaceName, contents);

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -27,9 +27,9 @@ ${contents}
 }\n\n`;
 
 export const generateInterface = (interfaceName: string, fields: IField[]) => {
-  const sortedFields = fields.slice().sort((a, b) =>
-    a.fieldName.localeCompare(b.fieldName),
-  );
+  const sortedFields = fields
+    .slice()
+    .sort((a, b) => a.fieldName.localeCompare(b.fieldName));
   const contents = sortedFields
     .map(({ fieldName, fieldType }) => `  ${fieldName}: ${fieldType};`)
     .join('\n');

--- a/packages/example/src/books/books.queries.ts
+++ b/packages/example/src/books/books.queries.ts
@@ -12,10 +12,10 @@ export interface IFindBookByIdParams {
 
 /** 'FindBookById' return type */
 export interface IFindBookByIdResult {
-  id: number;
-  rank: number | null;
-  name: string | null;
   author_id: number | null;
+  id: number;
+  name: string | null;
+  rank: number | null;
 }
 
 /** 'FindBookById' query type */
@@ -69,8 +69,8 @@ export const insertBooks = new PreparedQuery<IInsertBooksParams,IInsertBooksResu
 
 /** 'UpdateBooksCustom' parameters type */
 export interface IUpdateBooksCustomParams {
-  rank: number | null | void;
   id: number;
+  rank: number | null | void;
 }
 
 /** 'UpdateBooksCustom' return type */
@@ -103,9 +103,9 @@ export const updateBooksCustom = new PreparedQuery<IUpdateBooksCustomParams,IUpd
 
 /** 'UpdateBooks' parameters type */
 export interface IUpdateBooksParams {
+  id: number;
   name: string | null | void;
   rank: number | null | void;
-  id: number;
 }
 
 /** 'UpdateBooks' return type */
@@ -140,10 +140,10 @@ export interface IGetBooksByAuthorNameParams {
 
 /** 'GetBooksByAuthorName' return type */
 export interface IGetBooksByAuthorNameResult {
-  id: number;
-  rank: number | null;
-  name: string | null;
   author_id: number | null;
+  id: number;
+  name: string | null;
+  rank: number | null;
 }
 
 /** 'GetBooksByAuthorName' query type */
@@ -172,8 +172,8 @@ export interface IAggregateEmailsAndTestParams {
 
 /** 'AggregateEmailsAndTest' return type */
 export interface IAggregateEmailsAndTestResult {
-  emails: stringArray | null;
   agetest: boolean | null;
+  emails: stringArray | null;
 }
 
 /** 'AggregateEmailsAndTest' query type */

--- a/packages/example/src/comments/comments.queries.ts
+++ b/packages/example/src/comments/comments.queries.ts
@@ -8,10 +8,10 @@ export interface IGetAllCommentsParams {
 
 /** 'GetAllComments' return type */
 export interface IGetAllCommentsResult {
+  body: string | null;
+  book_id: number | null;
   id: number;
   user_id: number | null;
-  book_id: number | null;
-  body: string | null;
 }
 
 /** 'GetAllComments' query type */
@@ -25,7 +25,7 @@ const getAllCommentsIR: any = {"name":"GetAllComments","params":[{"name":"id","r
 /**
  * Query generated from SQL:
  * ```
- * SELECT * FROM book_comments WHERE id = :id! OR user_id = :id
+ * SELECT * FROM book_comments WHERE id = :id! OR user_id = :id                                      
  * ```
  */
 export const getAllComments = new PreparedQuery<IGetAllCommentsParams,IGetAllCommentsResult>(getAllCommentsIR);
@@ -38,10 +38,10 @@ export interface IGetAllCommentsByIdsParams {
 
 /** 'GetAllCommentsByIds' return type */
 export interface IGetAllCommentsByIdsResult {
+  body: string | null;
+  book_id: number | null;
   id: number;
   user_id: number | null;
-  book_id: number | null;
-  body: string | null;
 }
 
 /** 'GetAllCommentsByIds' query type */

--- a/packages/example/src/notifications/notifications.queries.ts
+++ b/packages/example/src/notifications/notifications.queries.ts
@@ -45,9 +45,9 @@ export interface IGetNotificationsParams {
 /** 'GetNotifications' return type */
 export interface IGetNotificationsResult {
   id: number;
-  user_id: number | null;
   payload: Json;
   type: notification_type;
+  user_id: number | null;
 }
 
 /** 'GetNotifications' query type */
@@ -76,9 +76,9 @@ export interface IThresholdFrogsParams {
 
 /** 'ThresholdFrogs' return type */
 export interface IThresholdFrogsResult {
-  user_name: string;
   payload: Json;
   type: notification_type;
+  user_name: string;
 }
 
 /** 'ThresholdFrogs' query type */

--- a/packages/example/src/notifications/notifications.types.ts
+++ b/packages/example/src/notifications/notifications.types.ts
@@ -45,9 +45,9 @@ export type IGetAllNotificationsParams = void;
 /** 'GetAllNotifications' return type */
 export interface IGetAllNotificationsResult {
   id: number;
-  user_id: number | null;
   payload: Json;
   type: notification_type;
+  user_id: number | null;
 }
 
 /** 'GetAllNotifications' query type */

--- a/packages/example/src/users/sample.types.ts
+++ b/packages/example/src/users/sample.types.ts
@@ -7,13 +7,13 @@ export interface IGetUsersWithCommentsParams {
 
 /** 'GetUsersWithComments' return type */
 export interface IGetUsersWithCommentsResult {
-  id: number;
-  email: string;
-  user_name: string;
-  first_name: string | null;
-  last_name: string | null;
   age: number | null;
+  email: string;
+  first_name: string | null;
+  id: number;
+  last_name: string | null;
   registration_date: Date;
+  user_name: string;
 }
 
 /** 'GetUsersWithComments' query type */


### PR DESCRIPTION
Basically copy-paste of #204 

Our team uses pgtyped and we are getting lots of churn on pull requests and in git because the ordering of fields isn't deterministic. (depends on layout of fields in the database -- which can be different if some people applied migrations in different orders or rolled-back at some point in time).

This is a PR to sort the field names alphabetically.