### PR TITLE
Add support for empty array spread in WHERE IN

### DIFF
--- a/docs-new/docs/sql-file.md
+++ b/docs-new/docs/sql-file.md
@@ -90,6 +90,16 @@ selectSomeUsers.run(parameters, connection);
 SELECT FROM users WHERE age in ($1, $2, $3);
 ```
 
+The array spread expansion features support for empty lists _when used in `WHERE IN`_ statements.
+In these cases, instead of outputting `()` a tautology condition is placed instead (condition cannot be trivially omittied, because it would break condition chaining with brackets and logical operators).
+
+Beware that this feature is not supported in other contexts, such as `VALUES()`. In that cases you will still see the SQL invalid `()`. Support for values is much more challenging to support, since there is no easy way to create an empty selection _with matching column set_ to the selection.
+
+```sql title="Resulting query with empty argument list:"
+-- Parameters: []
+SELECT FROM users WHERE 1 = 1 /* empty :ages */;
+```
+
 ### Object pick
 
 The object pick expansion allows to pass an object as a parameter.

--- a/packages/query/src/preprocessor-sql.test.ts
+++ b/packages/query/src/preprocessor-sql.test.ts
@@ -153,6 +153,48 @@ test('(SQL) array param', () => {
   expect(mappingResult).toEqual(expectedMappingResult);
 });
 
+test('(SQL) empty array param', () => {
+  const query = `
+  /*
+    @name selectSomeUsers
+    @param ages -> (...)
+  */
+  SELECT FROM users WHERE age in :ages;`;
+  const fileAST = parseSQLQuery(query);
+
+  const parameters = {
+    ages: [],
+  };
+
+  const expectedInterpolationResult = {
+    query: 'SELECT FROM users WHERE 1 = 1 /* empty :ages */',
+    bindings: [],
+    mapping: [],
+  };
+
+  const expectedMappingResult = {
+    query: 'SELECT FROM users WHERE age in ($1)',
+    bindings: [],
+    mapping: [
+      {
+        name: 'ages',
+        type: ParamTransform.Spread,
+        required: false,
+        assignedIndex: 1,
+      },
+    ]
+  };
+
+  const interpolationResult = processSQLQueryAST(
+    fileAST.queries[0],
+    parameters,
+  );
+  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+
+  expect(interpolationResult).toEqual(expectedInterpolationResult);
+  expect(mappingResult).toEqual(expectedMappingResult);
+});
+
 test('(SQL) array param used twice', () => {
   const query = `
   /*

--- a/packages/query/src/preprocessor-ts.test.ts
+++ b/packages/query/src/preprocessor-ts.test.ts
@@ -363,7 +363,7 @@ test('(TS) query with empty spread params', () => {
   const parsedQuery = parseTSQuery(query);
 
   const expectedResult = {
-    query: `SELECT * FROM users WHERE id IN ()`,
+    query: `SELECT * FROM users WHERE 1 = 1 /* empty $$ids */`,
     bindings: [],
     mapping: [],
   };


### PR DESCRIPTION
 - Extend `replaceIntervals` to handle empty where in (affects both SQL
   and TS)
 - Update docs & tests

**Implementation**

Function `replaceIntervals` can now detect, if the interval is part of
WHERE IN condition and can replace larger part of the query with an
tautological condition. The solution should work safetly for queries
that use `()` intentionally somewhere (comments) and that have the WHERE
IN nested in other conditional chains. If the replacement occurs, SQL
comment is added.

**Motivation**

Support for empty where-in is way more vital use-case
compared to support for values. Values are used most of the time for
creates and it does not make sense to have a create variant query for
the results: this should be validated beforehand instead.

If you do have a reasonably large query that has 3 optional WHERE IN
filters that you can construct with a query builder, with PgTyped, you'd
need to create all the possible combinations for the slight variances.

Fixes: https://github.com/adelsz/pgtyped/issues/273

Related: https://github.com/adelsz/pgtyped/issues/221
Related: https://github.com/adelsz/pgtyped/issues/314
Related: https://github.com/adelsz/pgtyped/issues/156