### PR TITLE
Introduce more stable SQL query IR

### DIFF
--- a/packages/example/src/books/books.queries.ts
+++ b/packages/example/src/books/books.queries.ts
@@ -29,7 +29,7 @@ export interface IFindBookByIdQuery {
   result: IFindBookByIdResult;
 }
 
-const findBookByIdIR: any = {"name":"FindBookById","params":[{"name":"id","required":false,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":57,"b":58,"line":2,"col":32}]}}],"usedParamSet":{"id":true},"statement":{"body":"SELECT * FROM books WHERE id = :id","loc":{"a":25,"b":58,"line":2,"col":0}}};
+const findBookByIdIR: any = {"usedParamSet":{"id":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":31,"b":33}]}],"statement":"SELECT * FROM books WHERE id = :id"};
 
 /**
  * Query generated from SQL:
@@ -61,7 +61,7 @@ export interface IInsertBooksQuery {
   result: IInsertBooksResult;
 }
 
-const insertBooksIR: any = {"name":"InsertBooks","params":[{"name":"books","codeRefs":{"defined":{"a":95,"b":99,"line":7,"col":9},"used":[{"a":212,"b":216,"line":10,"col":8}]},"transform":{"type":"pick_array_spread","keys":[{"name":"rank","required":true},{"name":"name","required":true},{"name":"authorId","required":true},{"name":"categories","required":false}]},"required":false}],"usedParamSet":{"books":true},"statement":{"body":"INSERT INTO books (rank, name, author_id, categories)\nVALUES :books RETURNING id as book_id","loc":{"a":150,"b":240,"line":9,"col":0}}};
+const insertBooksIR: any = {"usedParamSet":{"books":true},"params":[{"name":"books","required":false,"transform":{"type":"pick_array_spread","keys":[{"name":"rank","required":true},{"name":"name","required":true},{"name":"authorId","required":true},{"name":"categories","required":false}]},"locs":[{"a":61,"b":66}]}],"statement":"INSERT INTO books (rank, name, author_id, categories)\nVALUES :books RETURNING id as book_id"};
 
 /**
  * Query generated from SQL:
@@ -88,7 +88,7 @@ export interface IUpdateBooksCustomQuery {
   result: IUpdateBooksCustomResult;
 }
 
-const updateBooksCustomIR: any = {"name":"UpdateBooksCustom","params":[{"name":"rank","required":false,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":326,"b":329,"line":18,"col":20},{"a":372,"b":375,"line":19,"col":23}]}},{"name":"id","required":true,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":438,"b":440,"line":23,"col":12}]}}],"usedParamSet":{"rank":true,"id":true},"statement":{"body":"UPDATE books\nSET\n    rank = (\n        CASE WHEN (:rank::int IS NOT NULL)\n                 THEN :rank\n             ELSE rank\n            END\n        )\nWHERE id = :id!","loc":{"a":276,"b":440,"line":15,"col":0}}};
+const updateBooksCustomIR: any = {"usedParamSet":{"rank":true,"id":true},"params":[{"name":"rank","required":false,"transform":{"type":"scalar"},"locs":[{"a":49,"b":53},{"a":95,"b":99}]},{"name":"id","required":true,"transform":{"type":"scalar"},"locs":[{"a":161,"b":164}]}],"statement":"UPDATE books\nSET\n    rank = (\n        CASE WHEN (:rank::int IS NOT NULL)\n                 THEN :rank\n             ELSE rank\n            END\n        )\nWHERE id = :id!"};
 
 /**
  * Query generated from SQL:
@@ -123,7 +123,7 @@ export interface IUpdateBooksQuery {
   result: IUpdateBooksResult;
 }
 
-const updateBooksIR: any = {"name":"UpdateBooks","params":[{"name":"name","required":false,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":521,"b":524,"line":31,"col":12}]}},{"name":"rank","required":false,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":539,"b":542,"line":32,"col":12}]}},{"name":"id","required":true,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":556,"b":558,"line":33,"col":12}]}}],"usedParamSet":{"name":true,"rank":true,"id":true},"statement":{"body":"UPDATE books\n                     \nSET\n    name = :name,\n    rank = :rank\nWHERE id = :id!","loc":{"a":470,"b":558,"line":28,"col":0}}};
+const updateBooksIR: any = {"usedParamSet":{"name":true,"rank":true,"id":true},"params":[{"name":"name","required":false,"transform":{"type":"scalar"},"locs":[{"a":50,"b":54}]},{"name":"rank","required":false,"transform":{"type":"scalar"},"locs":[{"a":68,"b":72}]},{"name":"id","required":true,"transform":{"type":"scalar"},"locs":[{"a":85,"b":88}]}],"statement":"UPDATE books\n                     \nSET\n    name = :name,\n    rank = :rank\nWHERE id = :id!"};
 
 /**
  * Query generated from SQL:
@@ -155,7 +155,7 @@ export interface IUpdateBooksRankNotNullQuery {
   result: IUpdateBooksRankNotNullResult;
 }
 
-const updateBooksRankNotNullIR: any = {"name":"UpdateBooksRankNotNull","params":[{"name":"rank","required":true,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":628,"b":632,"line":40,"col":12}]}},{"name":"name","required":false,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":647,"b":650,"line":41,"col":12}]}},{"name":"id","required":true,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":664,"b":666,"line":42,"col":12}]}}],"usedParamSet":{"rank":true,"name":true,"id":true},"statement":{"body":"UPDATE books\nSET\n    rank = :rank!,\n    name = :name\nWHERE id = :id!","loc":{"a":599,"b":666,"line":38,"col":0}}};
+const updateBooksRankNotNullIR: any = {"usedParamSet":{"rank":true,"name":true,"id":true},"params":[{"name":"rank","required":true,"transform":{"type":"scalar"},"locs":[{"a":28,"b":33}]},{"name":"name","required":false,"transform":{"type":"scalar"},"locs":[{"a":47,"b":51}]},{"name":"id","required":true,"transform":{"type":"scalar"},"locs":[{"a":64,"b":67}]}],"statement":"UPDATE books\nSET\n    rank = :rank!,\n    name = :name\nWHERE id = :id!"};
 
 /**
  * Query generated from SQL:
@@ -190,7 +190,7 @@ export interface IGetBooksByAuthorNameQuery {
   result: IGetBooksByAuthorNameResult;
 }
 
-const getBooksByAuthorNameIR: any = {"name":"GetBooksByAuthorName","params":[{"name":"authorName","required":true,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":814,"b":824,"line":47,"col":44}]}}],"usedParamSet":{"authorName":true},"statement":{"body":"SELECT b.* FROM books b\nINNER JOIN authors a ON a.id = b.author_id\nWHERE a.first_name || ' ' || a.last_name = :authorName!","loc":{"a":703,"b":824,"line":45,"col":0}}};
+const getBooksByAuthorNameIR: any = {"usedParamSet":{"authorName":true},"params":[{"name":"authorName","required":true,"transform":{"type":"scalar"},"locs":[{"a":110,"b":121}]}],"statement":"SELECT b.* FROM books b\nINNER JOIN authors a ON a.id = b.author_id\nWHERE a.first_name || ' ' || a.last_name = :authorName!"};
 
 /**
  * Query generated from SQL:
@@ -220,7 +220,7 @@ export interface IAggregateEmailsAndTestQuery {
   result: IAggregateEmailsAndTestResult;
 }
 
-const aggregateEmailsAndTestIR: any = {"name":"AggregateEmailsAndTest","params":[{"name":"testAges","required":false,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":916,"b":923,"line":50,"col":53}]}}],"usedParamSet":{"testAges":true},"statement":{"body":"SELECT array_agg(email) as emails, array_agg(age) = :testAges as ageTest FROM users","loc":{"a":863,"b":945,"line":50,"col":0}}};
+const aggregateEmailsAndTestIR: any = {"usedParamSet":{"testAges":true},"params":[{"name":"testAges","required":false,"transform":{"type":"scalar"},"locs":[{"a":52,"b":60}]}],"statement":"SELECT array_agg(email) as emails, array_agg(age) = :testAges as ageTest FROM users"};
 
 /**
  * Query generated from SQL:

--- a/packages/example/src/comments/comments.queries.ts
+++ b/packages/example/src/comments/comments.queries.ts
@@ -20,7 +20,7 @@ export interface IGetAllCommentsQuery {
   result: IGetAllCommentsResult;
 }
 
-const getAllCommentsIR: any = {"name":"GetAllComments","params":[{"name":"id","required":true,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":101,"b":103,"line":3,"col":40},{"a":119,"b":120,"line":3,"col":58}]}}],"usedParamSet":{"id":true},"statement":{"body":"SELECT * FROM book_comments WHERE id = :id! OR user_id = :id                                      ","loc":{"a":61,"b":120,"line":3,"col":0}}};
+const getAllCommentsIR: any = {"usedParamSet":{"id":true},"params":[{"name":"id","required":true,"transform":{"type":"scalar"},"locs":[{"a":39,"b":42},{"a":57,"b":59}]}],"statement":"SELECT * FROM book_comments WHERE id = :id! OR user_id = :id                                      "};
 
 /**
  * Query generated from SQL:
@@ -50,7 +50,7 @@ export interface IGetAllCommentsByIdsQuery {
   result: IGetAllCommentsByIdsResult;
 }
 
-const getAllCommentsByIdsIR: any = {"name":"GetAllCommentsByIds","params":[{"name":"ids","codeRefs":{"defined":{"a":203,"b":205,"line":8,"col":9},"used":[{"a":260,"b":262,"line":10,"col":41},{"a":275,"b":278,"line":10,"col":56}]},"transform":{"type":"array_spread"},"required":true}],"usedParamSet":{"ids":true},"statement":{"body":"SELECT * FROM book_comments WHERE id in :ids AND id in :ids!","loc":{"a":219,"b":278,"line":10,"col":0}}};
+const getAllCommentsByIdsIR: any = {"usedParamSet":{"ids":true},"params":[{"name":"ids","required":true,"transform":{"type":"array_spread"},"locs":[{"a":40,"b":43},{"a":55,"b":59}]}],"statement":"SELECT * FROM book_comments WHERE id in :ids AND id in :ids!"};
 
 /**
  * Query generated from SQL:
@@ -78,7 +78,7 @@ export interface IInsertCommentQuery {
   result: IInsertCommentResult;
 }
 
-const insertCommentIR: any = {"name":"InsertComment","params":[{"name":"comments","codeRefs":{"defined":{"a":316,"b":323,"line":14,"col":9},"used":[{"a":410,"b":417,"line":17,"col":8}]},"transform":{"type":"pick_array_spread","keys":[{"name":"userId","required":true},{"name":"commentBody","required":true}]},"required":false}],"usedParamSet":{"comments":true},"statement":{"body":"INSERT INTO book_comments (user_id, body)\nVALUES :comments","loc":{"a":360,"b":417,"line":16,"col":0}}};
+const insertCommentIR: any = {"usedParamSet":{"comments":true},"params":[{"name":"comments","required":false,"transform":{"type":"pick_array_spread","keys":[{"name":"userId","required":true},{"name":"commentBody","required":true}]},"locs":[{"a":49,"b":57}]}],"statement":"INSERT INTO book_comments (user_id, body)\nVALUES :comments"};
 
 /**
  * Query generated from SQL:

--- a/packages/example/src/notifications/notifications.queries.ts
+++ b/packages/example/src/notifications/notifications.queries.ts
@@ -25,7 +25,7 @@ export interface ISendNotificationsQuery {
   result: ISendNotificationsResult;
 }
 
-const sendNotificationsIR: any = {"name":"SendNotifications","params":[{"name":"notifications","codeRefs":{"defined":{"a":38,"b":50,"line":3,"col":9},"used":[{"a":150,"b":162,"line":6,"col":8}]},"transform":{"type":"pick_array_spread","keys":[{"name":"user_id","required":true},{"name":"payload","required":true},{"name":"type","required":true}]},"required":false}],"usedParamSet":{"notifications":true},"statement":{"body":"INSERT INTO notifications (user_id, payload, type)\nVALUES :notifications RETURNING id as notification_id","loc":{"a":91,"b":194,"line":5,"col":0}}};
+const sendNotificationsIR: any = {"usedParamSet":{"notifications":true},"params":[{"name":"notifications","required":false,"transform":{"type":"pick_array_spread","keys":[{"name":"user_id","required":true},{"name":"payload","required":true},{"name":"type","required":true}]},"locs":[{"a":58,"b":71}]}],"statement":"INSERT INTO notifications (user_id, payload, type)\nVALUES :notifications RETURNING id as notification_id"};
 
 /**
  * Query generated from SQL:
@@ -56,7 +56,7 @@ export interface IGetNotificationsQuery {
   result: IGetNotificationsResult;
 }
 
-const getNotificationsIR: any = {"name":"GetNotifications","params":[{"name":"userId","required":false,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":275,"b":280,"line":11,"col":18}]}}],"usedParamSet":{"userId":true},"statement":{"body":"SELECT *\n  FROM notifications\n WHERE user_id = :userId","loc":{"a":227,"b":280,"line":9,"col":0}}};
+const getNotificationsIR: any = {"usedParamSet":{"userId":true},"params":[{"name":"userId","required":false,"transform":{"type":"scalar"},"locs":[{"a":47,"b":53}]}],"statement":"SELECT *\n  FROM notifications\n WHERE user_id = :userId"};
 
 /**
  * Query generated from SQL:
@@ -87,7 +87,7 @@ export interface IThresholdFrogsQuery {
   result: IThresholdFrogsResult;
 }
 
-const thresholdFrogsIR: any = {"name":"ThresholdFrogs","params":[{"name":"numFrogs","required":true,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":458,"b":466,"line":20,"col":46}]}}],"usedParamSet":{"numFrogs":true},"statement":{"body":"SELECT u.user_name, n.payload, n.type\nFROM notifications n\nINNER JOIN users u on n.user_id = u.id\nWHERE CAST (n.payload->'num_frogs' AS int) > :numFrogs!","loc":{"a":314,"b":466,"line":17,"col":0}}};
+const thresholdFrogsIR: any = {"usedParamSet":{"numFrogs":true},"params":[{"name":"numFrogs","required":true,"transform":{"type":"scalar"},"locs":[{"a":143,"b":152}]}],"statement":"SELECT u.user_name, n.payload, n.type\nFROM notifications n\nINNER JOIN users u on n.user_id = u.id\nWHERE CAST (n.payload->'num_frogs' AS int) > :numFrogs!"};
 
 /**
  * Query generated from SQL:

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -7,7 +7,7 @@ export {
 } from './preprocessor';
 
 export { processTSQueryAST } from './preprocessor-ts';
-export { processSQLQueryAST } from './preprocessor-sql';
+export { processSQLQueryIR } from './preprocessor-sql';
 
 export { AsyncQueue } from '@pgtyped/wire';
 
@@ -19,7 +19,9 @@ export {
 export {
   default as parseSQLFile,
   SQLQueryAST,
+  SQLQueryIR,
   prettyPrintEvents,
+  queryASTToIR,
 } from './loader/sql';
 
 export { default as sql, TaggedQuery, PreparedQuery } from './tag';

--- a/packages/query/src/preprocessor-sql.test.ts
+++ b/packages/query/src/preprocessor-sql.test.ts
@@ -1,5 +1,5 @@
-import parseSQLQuery from './loader/sql';
-import { processSQLQueryAST } from './preprocessor-sql';
+import parseSQLQuery, { queryASTToIR } from './loader/sql';
+import { processSQLQueryIR } from './preprocessor-sql';
 import { ParamTransform } from './preprocessor';
 
 test('(SQL) no params', () => {
@@ -16,11 +16,9 @@ test('(SQL) no params', () => {
     bindings: [],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
+  const mappingResult = processSQLQueryIR(queryIR);
 
   expect(interpolationResult).toEqual(expectedResult);
   expect(mappingResult).toEqual(expectedResult);
@@ -51,10 +49,8 @@ test('(SQL) two scalar params, one forced as non-null', () => {
     bindings: [123, 'name', 'id'],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
 
   expect(interpolationResult).toEqual(expectedInterpolationResult);
 });
@@ -95,11 +91,9 @@ test('(SQL) two scalar params', () => {
     bindings: [],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
+  const mappingResult = processSQLQueryIR(queryIR);
 
   expect(interpolationResult).toEqual(expectedInterpolationResult);
   expect(mappingResult).toEqual(expectedMappingResult);
@@ -134,11 +128,9 @@ test('(SQL) one param used twice', () => {
     bindings: [],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
+  const mappingResult = processSQLQueryIR(queryIR);
 
   expect(interpolationResult).toEqual(expectedInterpolationResult);
   expect(mappingResult).toEqual(expectedMappingResult);
@@ -176,11 +168,9 @@ test('(SQL) array param', () => {
     ],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
+  const mappingResult = processSQLQueryIR(queryIR);
 
   expect(interpolationResult).toEqual(expectedInterpolationResult);
   expect(mappingResult).toEqual(expectedMappingResult);
@@ -218,11 +208,9 @@ test('(SQL) array param used twice', () => {
     ],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
+  const mappingResult = processSQLQueryIR(queryIR);
 
   expect(interpolationResult).toEqual(expectedInterpolationResult);
   expect(mappingResult).toEqual(expectedMappingResult);
@@ -267,11 +255,9 @@ test('(SQL) array and scalar param', () => {
     ],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
+  const mappingResult = processSQLQueryIR(queryIR);
 
   expect(interpolationResult).toEqual(expectedInterpolationResult);
   expect(mappingResult).toEqual(expectedMappingResult);
@@ -321,13 +307,11 @@ test('(SQL) pick param', () => {
     ],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
   expect(interpolationResult).toEqual(expectedInterpolationResult);
 
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const mappingResult = processSQLQueryIR(queryIR);
   expect(mappingResult).toEqual(expectedMappingResult);
 });
 
@@ -375,13 +359,11 @@ test('(SQL) pick param used twice', () => {
     ],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
   expect(interpolationResult).toEqual(expectedInterpolationResult);
 
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const mappingResult = processSQLQueryIR(queryIR);
   expect(mappingResult).toEqual(expectedMappingResult);
 });
 
@@ -434,11 +416,9 @@ test('(SQL) pickSpread param', () => {
     mapping: expectedMapping,
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
+  const mappingResult = processSQLQueryIR(queryIR);
 
   expect(interpolationResult).toEqual(expectedInterpolationResult);
   expect(mappingResult).toEqual(expectedMappingResult);
@@ -494,11 +474,9 @@ test('(SQL) pickSpread param used twice', () => {
     mapping: expectedMapping,
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
+  const mappingResult = processSQLQueryIR(queryIR);
 
   expect(interpolationResult).toEqual(expectedInterpolationResult);
   expect(mappingResult).toEqual(expectedMappingResult);
@@ -533,11 +511,9 @@ test('(SQL) scalar param required and optional', () => {
     bindings: [],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
+  const mappingResult = processSQLQueryIR(queryIR);
 
   expect(interpolationResult).toEqual(expectedInterpolationResult);
   expect(mappingResult).toEqual(expectedMappingResult);
@@ -587,13 +563,11 @@ test('(SQL) pick param required', () => {
     ],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
   expect(interpolationResult).toEqual(expectedInterpolationResult);
 
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const mappingResult = processSQLQueryIR(queryIR);
   expect(mappingResult).toEqual(expectedMappingResult);
 });
 
@@ -629,11 +603,9 @@ test('(SQL) array param required', () => {
     ],
   };
 
-  const interpolationResult = processSQLQueryAST(
-    fileAST.queries[0],
-    parameters,
-  );
-  const mappingResult = processSQLQueryAST(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const interpolationResult = processSQLQueryIR(queryIR, parameters);
+  const mappingResult = processSQLQueryIR(queryIR);
 
   expect(interpolationResult).toEqual(expectedInterpolationResult);
   expect(mappingResult).toEqual(expectedMappingResult);

--- a/packages/query/src/preprocessor-sql.ts
+++ b/packages/query/src/preprocessor-sql.ts
@@ -1,4 +1,4 @@
-import { assert, SQLQueryAST, TransformType } from './loader/sql';
+import { assert, SQLQueryIR, TransformType } from './loader/sql';
 import {
   IInterpolatedQuery,
   INestedParameters,
@@ -12,22 +12,18 @@ import {
 } from './preprocessor';
 
 /* Processes query AST formed by new parser from pure SQL files */
-export const processSQLQueryAST = (
-  query: SQLQueryAST,
+export const processSQLQueryIR = (
+  queryIR: SQLQueryIR,
   passedParams?: IQueryParameters,
 ): IInterpolatedQuery => {
   const bindings: Scalar[] = [];
   const paramMapping: QueryParam[] = [];
-  const usedParams = query.params.filter((p) => p.name in query.usedParamSet);
-  const { a: statementStart } = query.statement.loc;
+  const usedParams = queryIR.params.filter(
+    (p) => p.name in queryIR.usedParamSet,
+  );
   let i = 1;
   const intervals: { a: number; b: number; sub: string }[] = [];
   for (const usedParam of usedParams) {
-    const paramLocs = usedParam.codeRefs.used.map(({ a, b }) => ({
-      a: a - statementStart - 1,
-      b: b - statementStart,
-    }));
-
     // Handle spread transform
     if (usedParam.transform.type === TransformType.ArraySpread) {
       let sub: string;
@@ -49,9 +45,9 @@ export const processSQLQueryAST = (
         } as IScalarArrayParam);
         sub = `$${idx}`;
       }
-      paramLocs.forEach((pl) =>
+      usedParam.locs.forEach((loc) =>
         intervals.push({
-          ...pl,
+          ...loc,
           sub: `(${sub})`,
         }),
       );
@@ -90,9 +86,9 @@ export const processSQLQueryAST = (
         });
       }
 
-      paramLocs.forEach((pl) =>
+      usedParam.locs.forEach((loc) =>
         intervals.push({
-          ...pl,
+          ...loc,
           sub: `(${sub})`,
         }),
       );
@@ -140,9 +136,9 @@ export const processSQLQueryAST = (
         });
       }
 
-      paramLocs.forEach((pl) =>
+      usedParam.locs.forEach((loc) =>
         intervals.push({
-          ...pl,
+          ...loc,
           sub: `(${sub})`,
         }),
       );
@@ -163,14 +159,14 @@ export const processSQLQueryAST = (
       } as IScalarParam);
     }
 
-    paramLocs.forEach((pl) =>
+    usedParam.locs.forEach((loc) =>
       intervals.push({
-        ...pl,
+        ...loc,
         sub: `$${assignedIndex}`,
       }),
     );
   }
-  const flatStr = replaceIntervals(query.statement.body, intervals);
+  const flatStr = replaceIntervals(queryIR.statement, intervals);
   return {
     mapping: paramMapping,
     query: flatStr,

--- a/packages/query/src/tag.ts
+++ b/packages/query/src/tag.ts
@@ -1,6 +1,6 @@
 import { processTSQueryAST } from './preprocessor-ts';
-import { processSQLQueryAST } from './preprocessor-sql';
-import { Query as QueryAST } from './loader/sql';
+import { processSQLQueryIR } from './preprocessor-sql';
+import { QueryIR } from './loader/sql';
 import { parseTSQuery, TSQueryAST } from './loader/typescript';
 
 export interface IDatabaseConnection {
@@ -48,13 +48,13 @@ export class PreparedQuery<TParamType, TResultType> {
     dbConnection: IDatabaseConnection,
   ) => Promise<Array<TResultType>>;
 
-  private readonly query: QueryAST;
+  private readonly queryIR: QueryIR;
 
-  constructor(query: QueryAST) {
-    this.query = query;
+  constructor(queryIR: QueryIR) {
+    this.queryIR = queryIR;
     this.run = async (params, connection) => {
-      const { query: processedQuery, bindings } = processSQLQueryAST(
-        this.query,
+      const { query: processedQuery, bindings } = processSQLQueryIR(
+        this.queryIR,
         params as any,
       );
       const result = await connection.query(processedQuery, bindings);


### PR DESCRIPTION
Previously the query AST was used as the IR, which was functional, but
contained absolute line numbers and character offsets that would change
any time queries earlier in the file were changed. This made conflict
resolution particularly painful and would generally result in merge
conflicts.

Fixes adelsz/pgtyped#398

The strategy here is to introduce a dedicated IR interface rather than just using the AST structure. The dedicated IR structure removes unnecessary data, and normalizes the locations to be relative to the start of the query, rather than the start of the file. This means changes to queries don't cause side effects to other queries.