### PR TITLE
Add .npmignore to slim packages

### DIFF
--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -1,0 +1,4 @@
+src/**/*
+lib/**/*.test.*
+tsconfig.json
+*.tgz

--- a/packages/query/.npmignore
+++ b/packages/query/.npmignore
@@ -1,0 +1,4 @@
+src/**/*
+lib/**/*.test.*
+tsconfig.json
+*.tgz

--- a/packages/wire/.npmignore
+++ b/packages/wire/.npmignore
@@ -1,0 +1,4 @@
+src/**/*
+lib/**/*.test.*
+tsconfig.json
+*.tgz


### PR DESCRIPTION
The added .npmignore has exclude patterns to remove files from the
package that's published to NPM. The patterns are targeting
development-only files, i.e. TypeScript sources, tests, tsconfig.json