### PR TITLE
Include column comments in generated types

### DIFF
--- a/packages/cli/src/generator.test.ts
+++ b/packages/cli/src/generator.test.ts
@@ -36,6 +36,7 @@ describe('query-to-interface translation', () => {
             columnName: 'payload',
             type: 'json',
             nullable: false,
+            comment: 'Notification contents @type {Notification}',
           },
           {
             returnName: 'type',
@@ -80,6 +81,7 @@ export interface IGetNotificationsParams {
 
 /** 'GetNotifications' return type */
 export interface IGetNotificationsResult {
+  /** Notification contents @type {Notification} */
   payload: Json;
   type: PayloadType;
 }

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -19,6 +19,7 @@ import path from 'path';
 export interface IField {
   fieldName: string;
   fieldType: string;
+  comment?: string;
 }
 
 const interfaceGen = (interfaceName: string, contents: string) =>
@@ -31,7 +32,11 @@ export const generateInterface = (interfaceName: string, fields: IField[]) => {
     .slice()
     .sort((a, b) => a.fieldName.localeCompare(b.fieldName));
   const contents = sortedFields
-    .map(({ fieldName, fieldType }) => `  ${fieldName}: ${fieldType};`)
+    .map(
+      ({ fieldName, fieldType, comment }) =>
+        (comment ? `  /** ${comment} */\n` : '') +
+        `  ${fieldName}: ${fieldType};`,
+    )
     .join('\n');
   return interfaceGen(interfaceName, contents);
 };
@@ -89,7 +94,7 @@ export async function queryToTypeDeclarations(
   const returnFieldTypes: IField[] = [];
   const paramFieldTypes: IField[] = [];
 
-  returnTypes.forEach(({ returnName, type, nullable }) => {
+  returnTypes.forEach(({ returnName, type, nullable, comment }) => {
     let tsTypeName = types.use(type);
     if (nullable || nullable == null) {
       tsTypeName += ' | null';
@@ -100,6 +105,7 @@ export async function queryToTypeDeclarations(
         ? camelCase(returnName)
         : returnName,
       fieldType: tsTypeName,
+      comment,
     });
   });
 

--- a/packages/example/sql/schema.sql
+++ b/packages/example/sql/schema.sql
@@ -8,6 +8,8 @@ CREATE TABLE users (
   registration_date DATE NOT NULL DEFAULT CURRENT_DATE
 );
 
+COMMENT ON COLUMN users.age IS 'Age (in years)';
+
 CREATE TYPE notification_type AS ENUM ('notification', 'reminder', 'deadline');
 CREATE TYPE category AS ENUM ('thriller', 'science-fiction', 'novel');
 

--- a/packages/example/src/users/sample.types.ts
+++ b/packages/example/src/users/sample.types.ts
@@ -7,6 +7,7 @@ export interface IGetUsersWithCommentsParams {
 
 /** 'GetUsersWithComments' return type */
 export interface IGetUsersWithCommentsResult {
+  /** Age (in years) */
   age: number | null;
   email: string;
   first_name: string | null;


### PR DESCRIPTION
Postgres lets you attach comments to columns via the `COMMENT` command: https://www.postgresql.org/docs/current/sql-comment.html

This PR includes those as JSDoc / TSDoc comments in the types files that PgTyped generates. This has the advantage of making the comments appear in contextually appropriate places in editors that work with the TS language service, e.g. VS Code:

<img width="647" alt="image" src="https://user-images.githubusercontent.com/98301/157541840-4ab31b63-7f86-4bdf-b1c9-234af5ae7e69.png">

This seems like an overall usability win.

(Broader context: I mostly care about Postgres comments because I use them to attach TS Types to `json` / `jsonb` columns in Postgres, see https://github.com/danvk/pg-to-ts#json-types. So having these comments in source is pretty important for me. I think PgTyped is a great tool and I've got a few other contributions I'd like to make — would love to discuss them more in whatever what is most convenient.)