### PR TITLE
Add type mapping support for tsvector

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -76,6 +76,7 @@ export const DefaultTypeMapping = Object.freeze({
 
   // Extra types
   money: String,
+  tsvector: String,
   void: Void,
 
   // JSON types


### PR DESCRIPTION
This PR adds support for queries returning `tsvector`, by declaring that the value is encoded as a string. This is true at least when the pg library is used:

```sql
select to_tsvector('the cat ate the hat');
```

returns

```ts
{"to_tsvector": "'ate':3 'cat':2 'hat':5"}
```
