### PR TITLE
Narrow parameter types to readonly

### DIFF
--- a/packages/cli/src/generator.test.ts
+++ b/packages/cli/src/generator.test.ts
@@ -70,7 +70,7 @@ describe('query-to-interface translation', () => {
 
 export type PayloadType = 'dynamite' | 'message';
 
-export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };\n`;
+export type Json = null | boolean | number | string | readonly Json[] | { readonly [key: string]: Json };\n`;
 
       expect(types.declaration()).toEqual(expectedTypes);
       const expected = `/** 'GetNotifications' parameters type */
@@ -301,7 +301,7 @@ export interface IDeleteUsersQuery {
 
 export type PayloadType = 'dynamite' | 'message';
 
-export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };\n`;
+export type Json = null | boolean | number | string | readonly Json[] | { readonly [key: string]: Json };\n`;
 
       expect(types.declaration()).toEqual(expectedTypes);
       const expected = `/** 'GetNotifications' parameters type */
@@ -377,7 +377,7 @@ export interface IGetNotificationsQuery {
 
 export type PayloadType = 'dynamite' | 'message';
 
-export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };\n`;
+export type Json = null | boolean | number | string | readonly Json[] | { readonly [key: string]: Json };\n`;
 
       expect(types.declaration()).toEqual(expectedTypes);
       const expected = `/** 'GetNotifications' parameters type */
@@ -449,7 +449,7 @@ export interface IGetNotificationsQuery {
 
 export type PayloadType = 'dynamite' | 'message';
 
-export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };\n`;
+export type Json = null | boolean | number | string | readonly Json[] | { readonly [key: string]: Json };\n`;
 
       expect(types.declaration()).toEqual(expectedTypes);
       const expected = `/** 'GetNotifications' parameters type */

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -17,11 +17,11 @@ const Void: Type = { name: 'undefined' };
 const Json: Type = {
   name: 'Json',
   definition:
-    'null | boolean | number | string | Json[] | { [key: string]: Json }',
+    'null | boolean | number | string | readonly Json[] | { readonly [key: string]: Json }',
 };
 const getArray = (baseType: Type): Type => ({
   name: `${baseType.name}Array`,
-  definition: `(${baseType.definition ?? baseType.name})[]`,
+  definition: `readonly (${baseType.definition ?? baseType.name})[]`,
 });
 
 export const DefaultTypeMapping = Object.freeze({

--- a/packages/example/src/books/books.queries.ts
+++ b/packages/example/src/books/books.queries.ts
@@ -3,11 +3,11 @@ import { PreparedQuery } from '@pgtyped/query';
 
 export type category = 'novel' | 'science-fiction' | 'thriller';
 
-export type categoryArray = (category)[];
+export type categoryArray = readonly (category)[];
 
-export type numberArray = (number)[];
+export type numberArray = readonly (number)[];
 
-export type stringArray = (string)[];
+export type stringArray = readonly (string)[];
 
 /** 'FindBookById' parameters type */
 export interface IFindBookByIdParams {

--- a/packages/example/src/notifications/notifications.queries.ts
+++ b/packages/example/src/notifications/notifications.queries.ts
@@ -3,7 +3,7 @@ import { PreparedQuery } from '@pgtyped/query';
 
 export type notification_type = 'deadline' | 'notification' | 'reminder';
 
-export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+export type Json = null | boolean | number | string | readonly Json[] | { readonly [key: string]: Json };
 
 /** 'SendNotifications' parameters type */
 export interface ISendNotificationsParams {

--- a/packages/example/src/notifications/notifications.types.ts
+++ b/packages/example/src/notifications/notifications.types.ts
@@ -1,7 +1,7 @@
 /** Types generated for queries found in "src/notifications/notifications.ts" */
 export type notification_type = 'deadline' | 'notification' | 'reminder';
 
-export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+export type Json = null | boolean | number | string | readonly Json[] | { readonly [key: string]: Json };
 
 /** 'InsertNotifications' parameters type */
 export interface IInsertNotificationsParams {


### PR DESCRIPTION
This allows consumers to pass in readonly arrays.

I had a problem where in my application I was using `readonly` types for added safety, but then hit a problem where I couldn't pass those directly into Pgtyped.