### PR TITLE
Add links to GitHub in package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.2",
   "main": "lib/index.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adelsz/pgtyped.git"
+  },
+  "homepage": "https://github.com/adelsz/pgtyped",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -4,6 +4,11 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adelsz/pgtyped.git"
+  },
+  "homepage": "https://github.com/adelsz/pgtyped",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -4,6 +4,11 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adelsz/pgtyped.git"
+  },
+  "homepage": "https://github.com/adelsz/pgtyped",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
This is useful for people discovering the package on npm, and also for automated tools to resolve the sources from the package name.

For example these packages currently get a low score on [Snyk Package Advisor](https://snyk.io/advisor/npm-package/@pgtyped/cli) because it can't determine GitHub activity:

<img width="544" alt="image" src="https://user-images.githubusercontent.com/115310/194145503-65d57791-03cf-4b2e-b042-cb7958b746a0.png">
