### PR TITLE
Add types overrides

### DIFF
--- a/docs-new/docs/cli.md
+++ b/docs-new/docs/cli.md
@@ -65,6 +65,9 @@ These variables will override values provided in `config.json`.
     "host": "127.0.0.1", // DB host (optional)
     "port": 5432, // DB port (optional)
     "ssl": false // Whether or not to connect to DB with SSL (optional)
+  },
+  "typesOverrides": {
+    "date": "string" // Override default Postgres => TypeScript mapping
   }
 }
 ```

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -16,7 +16,7 @@ import { pascalCase } from 'pascal-case';
 import path from 'path';
 import { ParsedConfig } from './config';
 import { ProcessingMode } from './index';
-import { DefaultTypeMapping, TypeAllocator } from './types';
+import { TypeAllocator, TypeMapping } from './types';
 
 export interface IField {
   fieldName: string;
@@ -236,7 +236,7 @@ async function generateTypedecsFromFile(
   fileName: string,
   connection: any,
   mode: 'ts' | 'sql',
-  types: TypeAllocator = new TypeAllocator(DefaultTypeMapping),
+  types: TypeAllocator,
   config: ParsedConfig,
 ): Promise<ITypedQuery[]> {
   const results: ITypedQuery[] = [];
@@ -309,9 +309,10 @@ export async function generateDeclarationFile(
   fileName: string,
   connection: any,
   mode: 'ts' | 'sql',
-  types: TypeAllocator = new TypeAllocator(DefaultTypeMapping),
   config: ParsedConfig,
 ): Promise<{ typeDecs: ITypedQuery[]; declarationFileContents: string }> {
+  const types = new TypeAllocator(TypeMapping(config.typesOverrides));
+
   if (mode === 'sql') {
     types.use({ name: 'PreparedQuery', from: '@pgtyped/query' });
   }

--- a/packages/cli/src/worker.ts
+++ b/packages/cli/src/worker.ts
@@ -39,7 +39,6 @@ export async function processFile(
     fileName,
     connection,
     transform.mode,
-    void 0,
     config,
   );
   const relativePath = path.relative(process.cwd(), decsFileName);


### PR DESCRIPTION
Fix #475

A very straight forward PR that allows users to override some default Postgres type mapping. See #475 for a concreate example.