### PR TITLE
feat!: make nullable scalar parameters optional

### DIFF
--- a/packages/cli/src/generator.test.ts
+++ b/packages/cli/src/generator.test.ts
@@ -82,7 +82,7 @@ export type Json = null | boolean | number | string | Json[] | { [key: string]: 
       expect(types.declaration()).toEqual(expectedTypes);
       const expected = `/** 'GetNotifications' parameters type */
 export interface IGetNotificationsParams {
-  userId: string | null | void;
+  userId?: string | null | void;
 }
 
 /** 'GetNotifications' return type */
@@ -236,9 +236,9 @@ export interface IInsertNotificationsQuery {
       );
       const expected = `/** 'DeleteUsers' parameters type */
 export interface IDeleteUsersParams {
-  userId: string | null | void;
-  userName: string | null | void;
-  userNote: string | null | void;
+  userId?: string | null | void;
+  userName?: string | null | void;
+  userNote?: string | null | void;
 }
 
 /** 'DeleteUsers' return type */
@@ -314,7 +314,7 @@ export type Json = null | boolean | number | string | Json[] | { [key: string]: 
       expect(types.declaration()).toEqual(expectedTypes);
       const expected = `/** 'GetNotifications' parameters type */
 export interface IGetNotificationsParams {
-  userId: string | null | void;
+  userId?: string | null | void;
 }
 
 /** 'GetNotifications' return type */
@@ -462,7 +462,7 @@ export type Json = null | boolean | number | string | Json[] | { [key: string]: 
       expect(types.declaration()).toEqual(expectedTypes);
       const expected = `/** 'GetNotifications' parameters type */
 export interface IGetNotificationsParams {
-  userId: string | null | void;
+  userId?: string | null | void;
 }
 
 /** 'GetNotifications' return type */
@@ -534,7 +534,7 @@ export type Json = null | boolean | number | string | Json[] | { [key: string]: 
       expect(types.declaration()).toEqual(expectedTypes);
       const expected = `/** 'GetNotifications' parameters type */
 export interface IGetNotificationsParams {
-  userId: string | null | void;
+  userId?: string | null | void;
 }
 
 /** 'GetNotifications' return type */

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -27,6 +27,7 @@ export enum ProcessingMode {
 }
 
 export interface IField {
+  optional?: boolean;
   fieldName: string;
   fieldType: string;
   comment?: string;
@@ -47,9 +48,9 @@ export const generateInterface = (interfaceName: string, fields: IField[]) => {
     .sort((a, b) => a.fieldName.localeCompare(b.fieldName));
   const contents = sortedFields
     .map(
-      ({ fieldName, fieldType, comment }) =>
+      ({ fieldName, fieldType, comment, optional }) =>
         (comment ? `  /** ${escapeComment(comment)} */\n` : '') +
-        `  ${fieldName}: ${fieldType};`,
+        `  ${fieldName}${optional ? '?' : ''}: ${fieldType};`,
     )
     .join('\n');
   return interfaceGen(interfaceName, contents);
@@ -153,7 +154,12 @@ export async function queryToTypeDeclarations(
         tsTypeName += ' | null | void';
       }
 
+      // Allow optional scalar parameters to be missing from parameters object
+      const optional =
+        param.type === ParameterTransform.Scalar && !param.required;
+
       paramFieldTypes.push({
+        optional,
         fieldName: param.name,
         fieldType: isArray ? `readonly (${tsTypeName})[]` : tsTypeName,
       });

--- a/packages/example/src/__snapshots__/index.test.ts.snap
+++ b/packages/example/src/__snapshots__/index.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`select query with dynamic or 1`] = `
+Array [
+  Object {
+    "id": 1,
+    "name": "Black Swan",
+  },
+]
+`;
+
 exports[`select query with join and a parameter override 1`] = `
 Array [
   Object {

--- a/packages/example/src/books/books.queries.ts
+++ b/packages/example/src/books/books.queries.ts
@@ -11,7 +11,7 @@ export type stringArray = (string)[];
 
 /** 'FindBookById' parameters type */
 export interface IFindBookByIdParams {
-  id: number | null | void;
+  id?: number | null | void;
 }
 
 /** 'FindBookById' return type */
@@ -38,6 +38,37 @@ const findBookByIdIR: any = {"usedParamSet":{"id":true},"params":[{"name":"id","
  * ```
  */
 export const findBookById = new PreparedQuery<IFindBookByIdParams,IFindBookByIdResult>(findBookByIdIR);
+
+
+/** 'FindBookNameOrRank' parameters type */
+export interface IFindBookNameOrRankParams {
+  name?: string | null | void;
+  rank?: number | null | void;
+}
+
+/** 'FindBookNameOrRank' return type */
+export interface IFindBookNameOrRankResult {
+  id: number;
+  name: string | null;
+}
+
+/** 'FindBookNameOrRank' query type */
+export interface IFindBookNameOrRankQuery {
+  params: IFindBookNameOrRankParams;
+  result: IFindBookNameOrRankResult;
+}
+
+const findBookNameOrRankIR: any = {"usedParamSet":{"name":true,"rank":true},"params":[{"name":"name","required":false,"transform":{"type":"scalar"},"locs":[{"a":41,"b":45}]},{"name":"rank","required":false,"transform":{"type":"scalar"},"locs":[{"a":57,"b":61}]}],"statement":"SELECT id, name\nFROM books\nWHERE (name = :name OR rank = :rank)"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT id, name
+ * FROM books
+ * WHERE (name = :name OR rank = :rank)
+ * ```
+ */
+export const findBookNameOrRank = new PreparedQuery<IFindBookNameOrRankParams,IFindBookNameOrRankResult>(findBookNameOrRankIR);
 
 
 /** 'FindBookUnicode' parameters type */
@@ -105,7 +136,7 @@ export const insertBooks = new PreparedQuery<IInsertBooksParams,IInsertBooksResu
 /** 'UpdateBooksCustom' parameters type */
 export interface IUpdateBooksCustomParams {
   id: number;
-  rank: number | null | void;
+  rank?: number | null | void;
 }
 
 /** 'UpdateBooksCustom' return type */
@@ -139,8 +170,8 @@ export const updateBooksCustom = new PreparedQuery<IUpdateBooksCustomParams,IUpd
 /** 'UpdateBooks' parameters type */
 export interface IUpdateBooksParams {
   id: number;
-  name: string | null | void;
-  rank: number | null | void;
+  name?: string | null | void;
+  rank?: number | null | void;
 }
 
 /** 'UpdateBooks' return type */
@@ -171,7 +202,7 @@ export const updateBooks = new PreparedQuery<IUpdateBooksParams,IUpdateBooksResu
 /** 'UpdateBooksRankNotNull' parameters type */
 export interface IUpdateBooksRankNotNullParams {
   id: number;
-  name: string | null | void;
+  name?: string | null | void;
   rank: number;
 }
 
@@ -234,7 +265,7 @@ export const getBooksByAuthorName = new PreparedQuery<IGetBooksByAuthorNameParam
 
 /** 'AggregateEmailsAndTest' parameters type */
 export interface IAggregateEmailsAndTestParams {
-  testAges: numberArray | null | void;
+  testAges?: numberArray | null | void;
 }
 
 /** 'AggregateEmailsAndTest' return type */

--- a/packages/example/src/books/books.sql
+++ b/packages/example/src/books/books.sql
@@ -1,6 +1,11 @@
 /* @name FindBookById */
 SELECT * FROM books WHERE id = :id;
 
+/* @name FindBookNameOrRank */
+SELECT id, name
+FROM books
+WHERE (name = :name OR rank = :rank);
+
 /* @name FindBookUnicode */
 SELECT * FROM books WHERE name = 'שקל';
 

--- a/packages/example/src/index.test.ts
+++ b/packages/example/src/index.test.ts
@@ -2,14 +2,15 @@ import {test, expect, afterEach, beforeEach, beforeAll, describe} from '@jest/gl
 import pg from 'pg';
 const {Client} = pg;
 import {
-  aggregateEmailsAndTest,
-  findBookUnicode,
-  findBookById,
-  getBooksByAuthorName,
-  insertBooks,
-  updateBooks,
-  updateBooksCustom,
-  updateBooksRankNotNull,
+    aggregateEmailsAndTest,
+    findBookUnicode,
+    findBookById,
+    getBooksByAuthorName,
+    insertBooks,
+    updateBooks,
+    updateBooksCustom,
+    updateBooksRankNotNull,
+    findBookNameOrRank,
 } from './books/books.queries.js';
 import { getAllComments } from './comments/comments.queries.js';
 import {
@@ -61,6 +62,13 @@ test('select query with unicode characters', () => {
 test('select query with parameters', async () => {
     const comments = await getAllComments.run({ id: 1 }, client);
     expect(comments).toMatchSnapshot();
+})
+
+test('select query with dynamic or', () => {
+    const result = findBookNameOrRank.run({
+        rank: 1,
+    }, client);
+    expect(result).resolves.toMatchSnapshot();
 })
 
 test('select query with date type override (TS)', async () => {

--- a/packages/example/src/notifications/notifications.queries.ts
+++ b/packages/example/src/notifications/notifications.queries.ts
@@ -39,7 +39,7 @@ export const sendNotifications = new PreparedQuery<ISendNotificationsParams,ISen
 
 /** 'GetNotifications' parameters type */
 export interface IGetNotificationsParams {
-  userId: number | null | void;
+  userId?: number | null | void;
 }
 
 /** 'GetNotifications' return type */


### PR DESCRIPTION
Nullable scalar parameters can now be omitted from parameter objects:
```diff
export interface IGetNotificationsParams {
-  userId: string | null | void;
+  userId?: string | null | void;
}
```
Meaning you no longer have to pass `undefined` explicitly to such queries:
```diff
const result = findBookNameOrRank.run({
  rank: 1,
- name: undefined
}, client);
```