### PR TITLE
Missing dep

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "pgtyped": "lib/index.js"
   },
   "dependencies": {
+    "@pgtyped/parser": "^2.1.0",
     "@pgtyped/query": "^2.1.0",
     "@pgtyped/wire": "^2.1.0",
     "camel-case": "^4.1.1",


### PR DESCRIPTION
Using yarn berry I have detected this:

```
node:internal/event_target:1010
  process.nextTick(() => { throw err; });
                           ^
Error: @pgtyped/cli tried to access @pgtyped/parser, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @pgtyped/parser (via "@pgtyped/parser/package.json")
Required by: @pgtyped/cli@virtual:a0ba3d3cda9824c28dd8fd0178ccbd7bc86eb7f53d38543771df1887d0bc057caad9034577859ad1cbfd031b50c5c91f73d6ffe7e42882783fd34e4f1a7cc8fb#npm:2.1.0 (via /home/lizard/Projects/coprali/coprali-nodejs/.yarn/__virtual__/@pgtyped-cli-virtual-cee4d22642/0/cache/@pgtyped-cli-npm-2.1.0-02c65e08f0-86ee7ec2a0.zip/node_modules/@pgtyped/cli/lib/generator.js)
```
