### PR TITLE
chore: upgrade TypeScript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "glob": "^9.0.0",
         "io-ts": "^2.1.2"
       },
       "devDependencies": {
@@ -26,7 +25,7 @@
         "tslint": "6.1.3",
         "tslint-config-prettier": "1.18.0",
         "tslint-plugin-prettier": "2.3.0",
-        "typescript": "4.9.4"
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3430,6 +3429,18 @@
         "nx": ">= 14 <= 16"
       }
     },
+    "node_modules/@nrwl/devkit/node_modules/@phenomnomnominal/tsquery": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
+      "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
+      "dev": true,
+      "dependencies": {
+        "esquery": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "^3 || ^4"
+      }
+    },
     "node_modules/@nrwl/devkit/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -3455,6 +3466,20 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@nrwl/devkit/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@nrwl/devkit/node_modules/yallist": {
@@ -3681,18 +3706,6 @@
     "node_modules/@pgtyped/wire": {
       "resolved": "packages/wire",
       "link": true
-    },
-    "node_modules/@phenomnomnominal/tsquery": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
-      "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
-      "dev": true,
-      "dependencies": {
-        "esquery": "^1.0.1"
-      },
-      "peerDependencies": {
-        "typescript": "^3 || ^4"
-      }
     },
     "node_modules/@scarf/scarf": {
       "version": "1.1.1",
@@ -5652,9 +5665,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -7898,6 +7911,19 @@
       },
       "engines": {
         "node": "^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/lerna/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/leven": {
@@ -12064,15 +12090,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/uglify-js": {
@@ -12588,7 +12614,7 @@
         "node": ">=14.16"
       },
       "peerDependencies": {
-        "typescript": "3.1 - 4"
+        "typescript": "3.1 - 5"
       }
     },
     "packages/example": {
@@ -12608,6 +12634,18 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "packages/example/node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "packages/parser": {
@@ -15304,6 +15342,15 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
+        "@phenomnomnominal/tsquery": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
+          "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
+          "dev": true,
+          "requires": {
+            "esquery": "^1.0.1"
+          }
+        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -15321,6 +15368,13 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "dev": true,
+          "peer": true
         },
         "yallist": {
           "version": "4.0.0",
@@ -15517,6 +15571,13 @@
         "pg": "8.10.0",
         "ts-node": "10.9.1",
         "typescript": "4.9.4"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.9.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+          "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
+        }
       }
     },
     "@pgtyped/parser": {
@@ -15566,15 +15627,6 @@
           "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w==",
           "dev": true
         }
-      }
-    },
-    "@phenomnomnominal/tsquery": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
-      "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
-      "dev": true,
-      "requires": {
-        "esquery": "^1.0.1"
       }
     },
     "@scarf/scarf": {
@@ -17111,9 +17163,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -18832,6 +18884,14 @@
         "npmlog": "^6.0.2",
         "nx": ">=15.4.2 < 16",
         "typescript": "^3 || ^4"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "dev": true
+        }
       }
     },
     "leven": {
@@ -21985,9 +22045,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tslint": "6.1.3",
     "tslint-config-prettier": "1.18.0",
     "tslint-plugin-prettier": "2.3.0",
-    "typescript": "4.9.4"
+    "typescript": "5.0.4"
   },
   "dependencies": {
     "io-ts": "^2.1.2"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,6 +61,6 @@
     "@types/yargs": "17.0.24"
   },
   "peerDependencies": {
-    "typescript": "3.1 - 4"
+    "typescript": "3.1 - 5"
   }
 }


### PR DESCRIPTION
This PR upgrades the TypeScript version to latest 5.0.4 as well as update the cli peer dependency to fix this issue: https://github.com/adelsz/pgtyped/issues/511