### PR TITLE
Template ENV vars in config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12696,7 +12696,7 @@
       "devDependencies": {
         "@types/chalk": "^2.2.0",
         "@types/debug": "^4.1.4",
-        "esbuild": "^0.17.19"
+        "esbuild": "^0.17.4"
       },
       "engines": {
         "node": ">=14.16"
@@ -15610,7 +15610,7 @@
         "@types/debug": "^4.1.4",
         "chalk": "^4.1.0",
         "debug": "^4.1.1",
-        "esbuild": "0.17.19"
+        "esbuild": "^0.17.4"
       }
     },
     "@pgtyped/wire": {

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,0 +1,89 @@
+import { DBConfigArgs, getEnvDBConfig } from './config';
+
+describe('getEnvDBConfig', () => {
+  const env = {
+    ...process.env,
+  };
+
+  beforeEach(() => {
+    // Default PG
+    process.env.PGHOST = 'pg_host';
+    process.env.PGUSER = 'pg_user';
+    process.env.PGPASSWORD = 'pg_password';
+    process.env.PGDATABASE = 'pg_db_name';
+    process.env.PGPORT = '1111';
+    process.env.PGURI = 'pg_uri';
+
+    // Custom
+    process.env.URI_ENV = 'host_from_env';
+    process.env.HOST_ENV = 'host_from_env';
+    process.env.USER_ENV = 'user_from_env';
+    process.env.PASSWORD_ENV = 'password_from_env';
+    process.env.DB_NAME_ENV = 'db_name_from_env';
+    process.env.PORT_ENV = '2222';
+    process.env.URI_ENV = 'uri_from_env';
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  test('Parses template ENV', () => {
+    const dbConfig: Partial<DBConfigArgs> = {
+      host: '{{HOST_ENV}}',
+      user: '{{USER_ENV}}',
+      password: '{{PASSWORD_ENV}}',
+      dbName: '{{DB_NAME_ENV}}',
+      port: '{{PORT_ENV}}',
+      uri: '{{URI_ENV}}',
+    };
+
+    const parsedConfig = getEnvDBConfig(dbConfig);
+
+    expect(parsedConfig).toEqual({
+      host: 'host_from_env',
+      user: 'user_from_env',
+      password: 'password_from_env',
+      dbName: 'db_name_from_env',
+      port: 2222,
+      uri: 'uri_from_env',
+    });
+  });
+
+  test('Parses default ENV', () => {
+    const dbConfig: Partial<DBConfigArgs> = {};
+
+    const parsedConfig = getEnvDBConfig(dbConfig);
+
+    expect(parsedConfig).toEqual({
+      host: 'pg_host',
+      user: 'pg_user',
+      password: 'pg_password',
+      dbName: 'pg_db_name',
+      port: 1111,
+      uri: 'pg_uri',
+    });
+  });
+
+  test('Parses default ENV with invalid templates', () => {
+    // All invalid templates
+    const dbConfig: Partial<DBConfigArgs> = {
+      host: '{{{HOST_ENV}}',
+      user: '{{USER_ENV}}}',
+      password: 'invalid',
+      dbName: '',
+      port: '1234',
+      uri: '_',
+    };
+    const parsedConfig = getEnvDBConfig(dbConfig);
+
+    expect(parsedConfig).toEqual({
+      host: undefined,
+      user: undefined,
+      password: 'pg_password',
+      dbName: 'pg_db_name',
+      port: 1111,
+      uri: 'pg_uri',
+    });
+  });
+});

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -37,7 +37,6 @@ describe('getEnvDBConfig', () => {
       port: '{{PORT_ENV}}',
       uri: '{{URI_ENV}}',
     };
-
     const parsedConfig = getEnvDBConfig(dbConfig);
 
     expect(parsedConfig).toEqual({
@@ -52,7 +51,6 @@ describe('getEnvDBConfig', () => {
 
   test('Parses default ENV', () => {
     const dbConfig: Partial<DBConfigArgs> = {};
-
     const parsedConfig = getEnvDBConfig(dbConfig);
 
     expect(parsedConfig).toEqual({


### PR DESCRIPTION
## Intent

In large projects and monorepos there may be multiple different databases, users, etc. This can be handled by having multiple 'config' files but this requires DB credentials to be committed into source control. Rather than being restricted to supporting only the common PG environment we can support specifying different ENV vars to use for each config.

## Changes

Keeping with the "template syntax" in the config file, consumers can provide their own ENV vars to use for a config. For example - 

```json
{
  "transforms": [
    {
      "mode": "sql",
      "include": "**/*.sql",
      "emitTemplate": "{{dir}}/{{name}}.queries.ts"
    },
  ],
  "srcDir": "./src/",
  "dbUrl": "{{MY_DB_URI}}",
  "db": {
    "host": "{{MY_HOST}}",
    "port": "{{MY_PORT}}",
    "user": "{{MY_USER}}",
    "dbName": "{{DB_NAME}}",
    "password": "{{MY_DB_PASSWORD}}"
  }
}
```

## Note

Im still doing a little more testing but wanted to open this up for review