### PR TITLE
fix: generate POSIX paths in typesOverrides imports

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "useWorkspaces": true,
   "version": "2.2.1"
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -159,8 +159,11 @@ export function declareImport(
   let from = imports[0].from;
 
   if (from.startsWith('.')) {
-    const nonPosixFrom = path.relative(path.dirname(decsFileName), imports[0].from);
-    from = nonPosixFrom.split(path.sep).join(path.posix.sep);
+    from = path.relative(path.dirname(decsFileName), imports[0].from);
+    if (os.platform() === "win32") {
+      // make sure we use posix separators in TS import declarations (see #533)
+      from = from.split(path.sep).join(path.posix.sep);
+    }
 
     if (!from.startsWith('.')) {
       from = './' + from;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -8,6 +8,7 @@ import {
   Type,
   ImportedType,
 } from '@pgtyped/query';
+import os from 'os';
 import path from 'path';
 
 const String: Type = { name: 'string' };

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -159,7 +159,8 @@ export function declareImport(
   let from = imports[0].from;
 
   if (from.startsWith('.')) {
-    from = path.relative(path.dirname(decsFileName), imports[0].from);
+    const nonPosixFrom = path.relative(path.dirname(decsFileName), imports[0].from);
+    from = nonPosixFrom.split(path.sep).join(path.posix.sep);
 
     if (!from.startsWith('.')) {
       from = './' + from;


### PR DESCRIPTION
**Describe the bug**

Generated imports for `typesOverrides`  contain backslashes instead of slashes on Windows.

![image](https://github.com/adelsz/pgtyped/assets/4543679/ad2f949e-fc66-49bf-ba49-0a921cd85e0f)

Relates to https://github.com/adelsz/pgtyped/issues/519

**Expected behavior**

Backslashes are invalid in TypeScript imports, so I expect it to generate the same import (with slashes) on both Unix systems and Windows.

**Test case**

- CLI v2.2.1 on a Win 11
- Add a `typesOverrides` configuration in your project
- Then run pgtyped build.
- You will see broken imports on top of generated TypeScript files
