### PR TITLE
Check permissions of queries via `EXPLAIN EXECUTE <stmt>;`

### DIFF
--- a/packages/example/config.json
+++ b/packages/example/config.json
@@ -25,5 +25,5 @@
     "category": { "return": "./src/customTypes.js#Category" }
   },
   "srcDir": "./src/",
-  "dbUrl": "postgres://postgres:password@localhost/postgres"
+  "dbUrl": "postgres://pgtyped_test:password@localhost/postgres"
 }

--- a/packages/example/docker-compose.yml
+++ b/packages/example/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         NODE_IMAGE: "node:${NODE_VERSION:-18}-alpine"
     environment:
       PGHOST: db
-      PGUSER: postgres
+      PGUSER: pgtyped_test
       PGDATABASE: postgres
       PGPASSWORD: password
       CI: $CI

--- a/packages/example/sql/schema.sql
+++ b/packages/example/sql/schema.sql
@@ -1,3 +1,11 @@
+-- Our test user; generally has all permissions; but some are revoked later.
+CREATE USER pgtyped_test WITH LOGIN PASSWORD 'password';
+GRANT CONNECT ON DATABASE postgres TO pgtyped_test;
+GRANT USAGE ON SCHEMA public TO pgtyped_test;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO pgtyped_test;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SEQUENCES TO pgtyped_test;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON FUNCTIONS TO pgtyped_test;
+
 CREATE TABLE users (
   id SERIAL PRIMARY KEY,
   email TEXT NOT NULL,
@@ -101,3 +109,20 @@ CREATE TABLE book_country (
 
 INSERT INTO book_country (country)
 VALUES ('CZ'), ('DE');
+
+-- This table has different insert/update permissions
+CREATE TABLE user_emails (
+  id int PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  address text NOT NULL UNIQUE,
+  receives_notifications boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+REVOKE ALL ON user_emails FROM pgtyped_test;
+GRANT
+  SELECT,
+  INSERT (address, receives_notifications),
+  UPDATE (receives_notifications),
+  DELETE
+ON user_emails TO pgtyped_test;

--- a/packages/example/src/user_emails/assert_fail.ts
+++ b/packages/example/src/user_emails/assert_fail.ts
@@ -1,0 +1,25 @@
+import { sql } from '@pgtyped/runtime';
+import {
+  IForbiddenInsertUserEmailWithIdParams,
+  IForbiddenInsertUserEmailWithIdResult,
+} from './assert_fail.types.js';
+import {
+  IInsertUserEmailParams,
+  IInsertUserEmailResult,
+} from './sample.types.js';
+import { Client } from 'pg';
+
+// This is forbidden since `INSERT` to `created_at` is not permitted
+const forbiddenInsertUserEmailWithId = sql`
+  INSERT INTO user_emails (address, receives_notifications, created_at)
+  VALUES $userEmail(address, receives_notifications, created_at)
+  RETURNING id;`;
+
+const assertForbiddenParamsIsNever: never = null as unknown as IForbiddenInsertUserEmailWithIdParams;
+const assertForbiddenResultIsNever: never = null as unknown as IForbiddenInsertUserEmailWithIdResult;
+
+// And just to check the above assertions are valid, we would expect these to error:
+// @ts-expect-error
+const assertRegularParamsIsNever: never = null as unknown as IInsertUserEmailParams;
+// @ts-expect-error
+const assertRegularResultIsNever: never = null as unknown as IInsertUserEmailResult;

--- a/packages/example/src/user_emails/sample.ts
+++ b/packages/example/src/user_emails/sample.ts
@@ -1,0 +1,19 @@
+import { sql } from '@pgtyped/runtime';
+import { IInsertUserEmailQuery } from './sample.types.js';
+import { Client } from 'pg';
+
+export async function insertUserEmail(
+  address: string,
+  receivesNotifications: boolean,
+  client: Client,
+) {
+  const insertUserEmail = sql<IInsertUserEmailQuery>`
+    INSERT INTO user_emails (address, receives_notifications)
+    VALUES $userEmail(address, receives_notifications)
+    RETURNING id;`;
+  const result = await insertUserEmail.run(
+    { userEmail: { address, receives_notifications: receivesNotifications } },
+    client,
+  );
+  return result[0];
+}

--- a/packages/example/src/user_emails/sample.ts
+++ b/packages/example/src/user_emails/sample.ts
@@ -1,10 +1,6 @@
 import { sql } from '@pgtyped/runtime';
 import {
   IInsertUserEmailQuery,
-  IInsertUserEmailParams,
-  IInsertUserEmailResult,
-  IForbiddenInsertUserEmailWithIdParams,
-  IForbiddenInsertUserEmailWithIdResult,
 } from './sample.types.js';
 import { Client } from 'pg';
 
@@ -23,17 +19,3 @@ export async function insertUserEmail(
   );
   return result[0];
 }
-
-const forbiddenInsertUserEmailWithId = sql`
-  INSERT INTO user_emails (id, address, receives_notifications)
-  VALUES $userEmail(id, address, receives_notifications)
-  RETURNING id;`;
-
-const assertForbiddenParamsIsNever: never = null as unknown as IForbiddenInsertUserEmailWithIdParams;
-const assertForbiddenResultIsNever: never = null as unknown as IForbiddenInsertUserEmailWithIdResult;
-
-// And just to check the above assertions are valid, we would expect these to error:
-// @ts-expect-error
-const assertRegularParamsIsNever: never = null as unknown as IInsertUserEmailParams;
-// @ts-expect-error
-const assertRegularResultIsNever: never = null as unknown as IInsertUserEmailResult;

--- a/packages/example/src/user_emails/sample.ts
+++ b/packages/example/src/user_emails/sample.ts
@@ -1,5 +1,11 @@
 import { sql } from '@pgtyped/runtime';
-import { IInsertUserEmailQuery } from './sample.types.js';
+import {
+  IInsertUserEmailQuery,
+  IInsertUserEmailParams,
+  IInsertUserEmailResult,
+  IForbiddenInsertUserEmailWithIdParams,
+  IForbiddenInsertUserEmailWithIdResult,
+} from './sample.types.js';
 import { Client } from 'pg';
 
 export async function insertUserEmail(
@@ -17,3 +23,17 @@ export async function insertUserEmail(
   );
   return result[0];
 }
+
+const forbiddenInsertUserEmailWithId = sql`
+  INSERT INTO user_emails (id, address, receives_notifications)
+  VALUES $userEmail(id, address, receives_notifications)
+  RETURNING id;`;
+
+const assertForbiddenParamsIsNever: never = null as unknown as IForbiddenInsertUserEmailWithIdParams;
+const assertForbiddenResultIsNever: never = null as unknown as IForbiddenInsertUserEmailWithIdResult;
+
+// And just to check the above assertions are valid, we would expect these to error:
+// @ts-expect-error
+const assertRegularParamsIsNever: never = null as unknown as IInsertUserEmailParams;
+// @ts-expect-error
+const assertRegularResultIsNever: never = null as unknown as IInsertUserEmailResult;

--- a/packages/example/src/user_emails/sample.types.ts
+++ b/packages/example/src/user_emails/sample.types.ts
@@ -19,11 +19,3 @@ export interface IInsertUserEmailQuery {
   result: IInsertUserEmailResult;
 }
 
-/** Query 'ForbiddenInsertUserEmailWithId' is invalid, so its result is assigned type 'never'.
- *  */
-export type IForbiddenInsertUserEmailWithIdResult = never;
-
-/** Query 'ForbiddenInsertUserEmailWithId' is invalid, so its parameters are assigned type 'never'.
- *  */
-export type IForbiddenInsertUserEmailWithIdParams = never;
-

--- a/packages/example/src/user_emails/sample.types.ts
+++ b/packages/example/src/user_emails/sample.types.ts
@@ -19,3 +19,11 @@ export interface IInsertUserEmailQuery {
   result: IInsertUserEmailResult;
 }
 
+/** Query 'ForbiddenInsertUserEmailWithId' is invalid, so its result is assigned type 'never'.
+ *  */
+export type IForbiddenInsertUserEmailWithIdResult = never;
+
+/** Query 'ForbiddenInsertUserEmailWithId' is invalid, so its parameters are assigned type 'never'.
+ *  */
+export type IForbiddenInsertUserEmailWithIdParams = never;
+

--- a/packages/example/src/user_emails/sample.types.ts
+++ b/packages/example/src/user_emails/sample.types.ts
@@ -1,0 +1,21 @@
+/** Types generated for queries found in "src/user_emails/sample.ts" */
+
+/** 'InsertUserEmail' parameters type */
+export interface IInsertUserEmailParams {
+  userEmail: {
+    address: string | null | void,
+    receives_notifications: boolean | null | void
+  };
+}
+
+/** 'InsertUserEmail' return type */
+export interface IInsertUserEmailResult {
+  id: number;
+}
+
+/** 'InsertUserEmail' query type */
+export interface IInsertUserEmailQuery {
+  params: IInsertUserEmailParams;
+  result: IInsertUserEmailResult;
+}
+

--- a/packages/query/src/actions.ts
+++ b/packages/query/src/actions.ts
@@ -191,10 +191,17 @@ type TypeData =
     }
   | IParseError;
 
+// Copied from https://github.com/brianc/node-postgres/blob/860cccd53105f7bc32fed8b1de69805f0ecd12eb/lib/client.js#L285-L302
+// Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
+// Replaced with regexp because it's 11x faster by Benjie.
+// Added `\0` escape because PostgreSQL strings cannot contain `\0` but JS strings can.
+export function escapeSqlIdentifier(str: string): string {
+  return `"${str.replace(/["\0]/g, '""')}"`;
+}
+
 /**
  * Returns the raw query type data as returned by the Describe message
  * @param query query string, can only contain proper Postgres numeric placeholders
- * @param query name, should be unique per query body
  * @param queue
  */
 export async function getTypeData(
@@ -248,6 +255,72 @@ export async function getTypeData(
   const fields = 'fields' in fieldsResult ? fieldsResult.fields : [];
   await queue.reply(messages.closeComplete);
   return { params, fields };
+}
+
+/**
+ * Checks that `EXPLAIN EXECUTE` of the prepared statement works, otherwise returns the error.
+ * @param query query string, can only contain proper Postgres numeric placeholders
+ * @param typeData type data, the result from getTypeData for this same query
+ * @param queue
+ */
+export async function explainQuery(
+  query: string,
+  typeData: TypeData,
+  queue: AsyncQueue,
+): Promise<string[] | IParseError> {
+  if ('errorCode' in typeData) return typeData;
+  const uniqueName = crypto.createHash('md5').update(query).digest('hex');
+  // Prepare query
+  await queue.send(messages.parse, {
+    name: uniqueName,
+    query,
+    dataTypes: [],
+  });
+  await queue.send(messages.flush, {});
+  const parseResult = await queue.reply(
+    messages.errorResponse,
+    messages.parseComplete,
+  );
+  try {
+    if ('fields' in parseResult) {
+      // Error case
+      const { fields: errorFields } = parseResult;
+      return {
+        errorCode: errorFields.R,
+        hint: errorFields.H,
+        message: errorFields.M,
+        position: errorFields.P,
+      };
+    }
+
+    // Explain query (will throw error on permissions failure). Leverages the
+    // fact that nullability is not checked in types at this stage, so `null` is
+    // a valid value for all types (yes, even domain types with a `non null`
+    // constraint).
+    const length = typeData.params.length;
+    const params = Array.from({ length }, () => 'null');
+    const explain = await runQuery(
+      `explain execute ${escapeSqlIdentifier(uniqueName)}${
+        params.length === 0 ? '' : ` (${params.join(', ')})`
+      };`,
+      queue,
+    );
+
+    return explain.map((e) => e[0]);
+  } finally {
+    // Release prepared statement
+    await queue.send(messages.close, {
+      target: PreparedObjectType.Statement,
+      targetName: uniqueName,
+    });
+
+    // Flush all messages
+    await queue.send(messages.flush, {});
+
+    // Recover server state from any errors
+    await queue.send(messages.sync, {});
+    await queue.reply(messages.closeComplete);
+  }
 }
 
 enum TypeCategory {
@@ -391,6 +464,7 @@ async function getComments(
   }));
 }
 
+const doTestRuns = true;
 export async function getTypes(
   queryData: InterpolatedQuery,
   queue: AsyncQueue,
@@ -398,6 +472,13 @@ export async function getTypes(
   const typeData = await getTypeData(queryData.query, queue);
   if ('errorCode' in typeData) {
     return typeData;
+  }
+
+  if (doTestRuns) {
+    const testRunResult = await explainQuery(queryData.query, typeData, queue);
+    if (testRunResult && 'errorCode' in testRunResult) {
+      return testRunResult;
+    }
   }
 
   const { params, fields } = typeData;


### PR DESCRIPTION
- Fixes #561

This PR adds an additional check before generating the types of a query, it runs something like `EXPLAIN EXECUTE prepared_statement_name (null, null, null, ...);` which doesn't actually run the query (that would be `EXPLAIN ANALYZE EXECUTE prepa...`) but does make the DB attempt to form a query plan for it, which will force some rudimentary query checks including, critically, the assertion of role-based access control.

This PR is not merge-able for (at least) the following reasons:

1. There are negative assertions that I don't understand how to make with your test suite (I want to assert that a given SQL query fails to generate types)
2. This is _currently_ a breaking change for people who are using `NOINHERIT` in their role configuration, since it only checks that the user in the connection string is capable of making the query, not the other roles it might become via `SET ROLE` (solution: opt-in via configuration setting? I've added a dummy variable for this.)
3. Undocumented

Also, potentially the logic of `explainQuery` should be merged into `getTypeData`? That's where I started, but the changes got too large so I figured it would be easier to review separately, plus easier to opt in/out of that way also.

I've done what I can to add to the tests, including creating a database role `pgtyped_test` to use instead of the `postgres` superuser role, making sure all previous tests still pass, adding a passing test about a new constraint `insert` query, and adding what should be negative assertions which I can see are picked up by the system:

```
Error processing src/user_emails/assert_fail.ts: permission denied for table user_emails                                                                                                                                                                          
undefined       
```

but I don't know how to check that or mark it as expected.

Note: for this to work for me I had to change the `test` script in packages/example/package.json` to:

```diff
-    "test": "docker-compose run build && docker-compose run test && docker-compose run test-cjs",
+    "test": "docker compose down && docker compose run build && docker compose run test && docker compose run test-cjs",
```

for two reasons: a) I needed the DB to shut down so it would re-initialize with the `schema.sql` script, and b) I don't have `docker-compose`, only `docker compose`.

Please feel very free to take over this pull request if you wish. Alternatively, if you're interested in supporting this feature, please let me know how I might best fix the issues outlined above.