### PR TITLE
Prevent ERR_OUT_OF_RANGE errors when reading messageSize from buffer

### DIFF
--- a/packages/wire/src/protocol.ts
+++ b/packages/wire/src/protocol.ts
@@ -112,6 +112,16 @@ export const parseMessage = <Params extends object>(
   messageOffset: number = 0,
 ): ParseResult<Params> => {
   let bufferOffset = messageOffset;
+
+  // Check if we have enough data to read the indicator and message size
+  // The + 5 is made up of 1 byte for readInt8 and 4 bytes for readUInt32BE
+  if (bufferOffset + 5 > buf.length) {
+    return {
+      type: "IncompleteMessageError",
+      messageName: message.name,
+    };
+  }
+
   const indicator = buf.readInt8(bufferOffset);
   const expectedIndicator = message.indicator.charCodeAt(0);
   const isUnexpectedErrorMessage =


### PR DESCRIPTION
Hi 👋 , this is a follow up to [this PR](https://github.com/adelsz/pgtyped/pull/487) from last year. We ran into an issue today where the `const messageSize = buf.readUInt32BE(bufferOffset);` line would cause an `ERR_OUT_OF_RANGE` error in about 1/5 executions of `pgtyped`. The error would always occur when parsing a file which referenced a large enum. The error began occurring when a change was merged to add two values to this enum. 

My suspicion is that the additional enum value has caused the boundary of the TCP packet splitting to land in the middle of the bytes making up the `messageSize` integer. The fix that I have implemented is to first check that the buffer has enough data to read the indicator and messageSize, before attempting to do so. 

I attempted to create a minimal reproduction, but was unable to. Running just the affected file resulted in the error occurring only about 1/20 executions, and I wasn't able to reproduce the error at all when I attempted to simplify the DB schema to just the large enum and associated tables.