### PR TITLE
Fix moduleResolution:node16 CommonJS compatibility

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -4,7 +4,11 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
+      "types": {
+        "import": "./lib/index.d.ts",
+        "require": "./lib/index.d.cts",
+        "default": "./lib/index.d.ts"
+      },
       "import": "./lib/index.js",
       "require": "./lib/index.cjs",
       "default": "./lib/index.js"
@@ -29,7 +33,7 @@
   "scripts": {
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "build:cjs": "esbuild --bundle --sourcemap --platform=node --target=node14 src/index.ts --minify --external:chalk --external:antlr4ts --outfile=lib/index.cjs",
-    "build": "tsc && npm run build:cjs",
+    "build": "tsc && npm run build:cjs && cp lib/index.d.ts lib/index.d.cts",
     "check": "tsc --noEmit",
     "watch": "tsc --watch --preserveWatchOutput"
   },


### PR DESCRIPTION
Fixes #570.

This fix was tested by applying the equivalent fix to a real project exhibiting the TypeScript issue and seeing if it would now compile (yes):

```patch
diff --git a/lib/index.d.cts b/lib/index.d.cts
new file mode 100644
index 0000000000000000000000000000000000000000..3d9337b5edcde8c7b8a98aa9cd81c6b1a1451542
--- /dev/null
+++ b/lib/index.d.cts
@@ -0,0 +1,4 @@
+export { ParameterTransform, QueryParameters, InterpolatedQuery, QueryParameter, } from './preprocessor.js';
+export { processTSQueryAST } from './preprocessor-ts.js';
+export { processSQLQueryIR } from './preprocessor-sql.js';
+export { sql, TaggedQuery, PreparedQuery } from './tag.js';
diff --git a/package.json b/package.json
index bed91dd3d360132d3e0b18375f4dc7d89cb4a10b..57491d5b4b2e6f5e87016a888a01001b8614a663 100644
--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
+      "types": {
+        "import": "./lib/index.d.ts",
+        "require": "./lib/index.d.cts",
+        "default": "./lib/index.d.ts"
+      },
       "import": "./lib/index.js",
       "require": "./lib/index.cjs",
       "default": "./lib/index.js"
```

and then by running `npm run build` and checking to see that `packages/runtime/lib/index.d.cts` exists (yes).

Thanks for your work on this project! :heart: 