### PR TITLE
Export IDatabaseConnection type

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8,4 +8,4 @@ export {
 export { processTSQueryAST } from './preprocessor-ts.js';
 export { processSQLQueryIR } from './preprocessor-sql.js';
 
-export { sql, TaggedQuery, PreparedQuery } from './tag.js';
+export { sql, TaggedQuery, PreparedQuery, IDatabaseConnection } from './tag.js';


### PR DESCRIPTION
This type is helpful to expose to calling code.  While updating our project to ESM I noticed its not exported.