### PR TITLE
feat!: Allow enforcing non-empty array parameters in config

### DIFF
--- a/docs-new/docs/cli.md
+++ b/docs-new/docs/cli.md
@@ -60,6 +60,7 @@ For a full list of options, see the [Configuration file format](#configuration-f
   "srcDir": "./src/", // Directory to scan or watch for query files
   "failOnError": false, // Whether to fail on a file processing error and abort generation (can be omitted - default is false)
   "camelCaseColumnNames": false, // convert to camelCase column names of result interface
+  "nonEmptyArrayParams": false, // Whether the type for an array parameter should exclude empty arrays
   "dbUrl": "postgres://user:password@host/database", // DB URL (optional - will be merged with db if provided)
   "db": {
     "dbName": "testdb", // DB name
@@ -92,6 +93,7 @@ Configuration file can be also be written in CommonJS format and default exporte
 | `failOnError?`          | `boolean`                | Whether to fail on a file processing error and abort generation. **Default:** `false`                                                                                      |
 | `dbUrl?`                | `string`                 | A connection string to the database. Example: `postgres://user:password@host/database`. Overrides (merged) with `db` config.                                               |
 | `camelCaseColumnNames?` | `boolean`                | Whether to convert column names to camelCase. _Note that this only coverts the types. You need to do this at runtime independently using a library like `pg-camelcase`_.   |
+| `nonEmptyArrayParams?`  | `boolean`                | Whether the types for arrays parameters exclude empty arrays. This helps prevent runtime errors when accidentally providing empty input to a query.                        |
 | `typesOverrides?`       | `Record<string, string>` | A map of type overrides. Similarly to `camelCaseColumnNames`, this only affects the types. _You need to do this at runtime independently using a library like `pg-types`._ |
 | `maxWorkerThreads`      | `number`                 | The maximum number of worker threads to use for type generation. **The default is based on the number of available CPUs.**                                                 | 
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -57,6 +57,7 @@ const configParser = t.type({
   failOnError: t.union([t.boolean, t.undefined]),
   camelCaseColumnNames: t.union([t.boolean, t.undefined]),
   hungarianNotation: t.union([t.boolean, t.undefined]),
+  nonEmptyArrayParams: t.union([t.boolean, t.undefined]),
   dbUrl: t.union([t.string, t.undefined]),
   db: t.union([
     t.type({
@@ -99,6 +100,7 @@ export interface ParsedConfig {
   failOnError: boolean;
   camelCaseColumnNames: boolean;
   hungarianNotation: boolean;
+  nonEmptyArrayParams: boolean;
   transforms: IConfig['transforms'];
   srcDir: IConfig['srcDir'];
   typesOverrides: Record<string, Partial<TypeDefinition>>;
@@ -198,6 +200,7 @@ export function parseConfig(
     failOnError,
     camelCaseColumnNames,
     hungarianNotation,
+    nonEmptyArrayParams,
     typesOverrides,
   } = configObject as IConfig;
 
@@ -242,6 +245,7 @@ export function parseConfig(
     failOnError: failOnError ?? false,
     camelCaseColumnNames: camelCaseColumnNames ?? false,
     hungarianNotation: hungarianNotation ?? true,
+    nonEmptyArrayParams: nonEmptyArrayParams ?? false,
     typesOverrides: parsedTypesOverrides,
     maxWorkerThreads,
   };


### PR DESCRIPTION
When using array parameters (including array spread and pick), providing an empty array to a parameter will usually cause a crash at runtime due to a syntax error.

For the following query, if an empty array is provided for userIds:

```
/*
  @name GetNotifications
  @param userIds -> (...)
*/
SELECT * FROM notifications WHERE id in :userIds!
```

As the query at runtime becomes:

```
SELECT * FROM notifications WHERE id in ()
```

Which results in:

```
ERROR:  syntax error at or near ")"
```

Therefore, this config forces the generated parameter type to only allow
non-empty arrays, i.e. the type `[T, ...T[]]` rather than `T[]`.