### PR TITLE
pgtyped on more runtimes: avoid relying on global `Buffer` type

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -24,7 +24,7 @@ const DateOrString: Type = {
   name: 'DateOrString',
   definition: 'Date | string',
 };
-const Bytes: Type = { name: 'Buffer' };
+const Bytes: Type = { name: 'Buffer', from: 'node:buffer' };
 const Void: Type = { name: 'undefined' };
 const Json: Type = {
   name: 'Json',


### PR DESCRIPTION
`Buffer` is not a global type inherent to Typescript (comes from nodejs) so not all compiler options support it. Therefore, using pgtyped in those environments can lead to a compiler error on the `Buffer` type

Tools usually solve this with two options:
1. Mock out the `node:buffer` module (so `import type { Buffer } from "node:buffer";` works)
2. Add `Buffer` to the global namespace

Adding to the global namespace is generally bad, so option (1) is usually preferred. However, pgtyped only supported option (2)

This PR changes so files generated from pgtyped include `import type { Buffer } from 'node:buffer';` in the generated code so that projects using pgtyped don't have to pollute their global namespace to get the project working. This reduces the need for hacks like https://github.com/adelsz/pgtyped/issues/262#issuecomment-2492838066