### PR TITLE
feat: add compile function to access raw queries

### DIFF
--- a/packages/runtime/src/tag.ts
+++ b/packages/runtime/src/tag.ts
@@ -1,6 +1,7 @@
 import { SQLQueryIR, parseTSQuery, TSQueryAST } from '@pgtyped/parser';
 import { processSQLQueryIR } from './preprocessor-sql.js';
 import { processTSQueryAST } from './preprocessor-ts.js';
+import { InterpolatedQuery } from "./preprocessor.js";
 
 export interface ICursor<T> {
   read(rowCount: number): Promise<T>;
@@ -46,6 +47,10 @@ export class TaggedQuery<TTypePair extends { params: any; result: any }> {
     dbConnection: IDatabaseConnection,
   ) => ICursor<Array<TTypePair['result']>>;
 
+  public compile: (
+    params: TTypePair['params'],
+  ) => InterpolatedQuery;
+
   private readonly query: TSQueryAST;
 
   constructor(query: TSQueryAST) {
@@ -76,6 +81,12 @@ export class TaggedQuery<TTypePair extends { params: any; result: any }> {
         },
       };
     };
+    this.compile = (params) => {
+      return processTSQueryAST(
+        this.query,
+        params as any,
+      );
+    }
   }
 }
 
@@ -107,6 +118,10 @@ export class PreparedQuery<TParamType, TResultType> {
     params: TParamType,
     dbConnection: IDatabaseConnection,
   ) => ICursor<Array<TResultType>>;
+
+  public compile: (
+    params: TParamType,
+  ) => InterpolatedQuery;
 
   private readonly queryIR: SQLQueryIR;
 
@@ -149,6 +164,12 @@ export class PreparedQuery<TParamType, TResultType> {
         },
       };
     };
+    this.compile = (params) => {
+      return processSQLQueryIR(
+        this.queryIR,
+        params as any,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
I want to combine pgtyped and [PGlite](https://pglite.dev). In order to make use of the [live query](https://pglite.dev/docs/live-queries) feature, I need access to the raw query.

This PR adds a `compile` method to `TaggedQuery` and `PreparedQuery` that returns the `InterpolatedQuery`.